### PR TITLE
Prefs: Rewrite for GTK4

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -5,4 +5,6 @@
   (org-indent-mode . t))
  (js-mode
   (mode . gnome-shell))
+ (js2-mode
+  (js2-basic-offset . 4))
  )

--- a/KeybindingsComboRow.ui
+++ b/KeybindingsComboRow.ui
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0" />
+  <template class="ComboRow" parent="GtkListBoxRow">
+    <property name="selectable">False</property>
+    <property name="activatable">True</property>
+    <property name="focusable">True</property>
+    <property name="focus-on-click">True</property>
+
+    <property name="child">
+      <object class="GtkStack" id="stack">
+        <child>
+          <object class="GtkStackPage">
+            <property name="child">
+              <object class="GtkBox" id="shortcutPage">
+                <property name="hexpand">True</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkShortcutLabel" id="shortcutLabel">
+                    <property name="disabled_text" translatable="yes">Disabled</property>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkMenuButton" id="conflictButton">
+                    <property name="tooltip_text" translatable="yes">Conflicts</property>
+                    <property name="icon_name">dialog-error-symbolic</property>
+                    <property name="popover">conflictPopover</property>
+                    <property name="visible">False</property>
+                    <style>
+                      <class name="flat" />
+                      <class name="circular" />
+                    </style>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkButton" id="deleteButton">
+                    <property name="hexpand">True</property>
+                    <property name="halign">end</property>
+                    <property name="tooltip_text" translatable="yes">Remove shortcut</property>
+                    <property name="icon_name">edit-clear-symbolic</property>
+                    <style>
+                      <class name="flat" />
+                      <class name="circular" />
+                    </style>
+                    <signal name="clicked" handler="_onDeleteButtonClicked" />
+                  </object>
+                </child>
+
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStackPage">
+            <property name="child">
+              <object class="GtkLabel" id="placeholderPage">
+                <property name="hexpand">True</property>
+                <property name="xalign">0.0</property>
+                <property name="use_markup">True</property>
+                <property name="label" translatable="yes">&lt;i&gt;Add shortcut…&lt;/i&gt;</property>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStackPage">
+            <property name="child">
+              <object class="GtkLabel" id="editPage">
+                <property name="use_markup">True</property>
+                <property name="label" translatable="yes">Enter keyboard shortcut, &lt;b&gt;Backspace&lt;/b&gt; to delete or &lt;b&gt;Esc&lt;/b&gt; to cancel</property>
+              </object>
+            </property>
+          </object>
+        </child>
+      </object>
+    </property>
+  </template>
+
+  <object class="GtkPopover" id="conflictPopover">
+    <child>
+      <object class="GtkBox" id="about">
+        <property name="focusable">False</property>
+        <property name="orientation">vertical</property>
+        <property name="margin-start">12</property>
+        <property name="margin-end">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
+        <property name="spacing">8</property>
+
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Conflicts:</property>
+            <style>
+              <class name="heading" />
+            </style>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkListBox" id="conflictList">
+            <property name="selection-mode">none</property>
+            <signal name="row-activated"
+                    handler="_onConflictRowActivated" />
+
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/KeybindingsPane.ui
+++ b/KeybindingsPane.ui
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <template class="KeybindingsPane" parent="GtkBox">
+    <property name="focusable">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkSearchEntry" id="search">
+        <property name="activates-default">False</property>
+        <property name="halign">center</property>
+        <property name="margin-top">12</property>
+        <signal name="search-changed"
+                handler="_onSearchChanged" />
+      </object>
+    </child>
+    <child>
+      <object class="GtkScrolledWindow">
+        <property name="hscrollbar_policy">never</property>
+        <child>
+          <object class="GtkViewport">
+            <property name="focusable">False</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkListBox" id="listbox">
+                <property name="hexpand">True</property>
+                <property name="margin_start">36</property>
+                <property name="margin_end">36</property>
+                <property name="margin_top">12</property>
+                <property name="margin_bottom">36</property>
+                <property name="width_request">480</property>
+                <style>
+                  <class name="keybindings" />
+                  <class name="frame" />
+                </style>
+                <signal name="row-activated"
+                        handler="_onRowActivated" />
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/KeybindingsRow.ui
+++ b/KeybindingsRow.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0" />
+  <template class="KeybindingsRow" parent="GtkListBoxRow">
+    <style>
+      <class name="keybinding" />
+    </style>
+    <property name="selectable">False</property>
+    <property name="activatable">True</property>
+    <property name="focusable">True</property>
+
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+
+        <child>
+          <object class="GtkBox" id="header">
+            <property name="spacing">12</property>
+            <style>
+              <class name="header" />
+            </style>
+
+            <child>
+              <object class="GtkLabel" id="descLabel">
+                <style>
+                  <class name="description" />
+                </style>
+                <property name="ellipsize">end</property>
+                <property name="halign">start</property>
+                <property name="lines">1</property>
+                <property name="wrap">True</property>
+                <property name="wrap-mode">word-char</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkImage" id="conflictIcon">
+                <property name="visible">False</property>
+                <property name="icon-name">dialog-error-symbolic</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkLabel" id="accelLabel">
+                <property name="hexpand">True</property>
+                <property name="halign">end</property>
+                <property name="xalign">1.0</property>
+                <property name="use-markup">True</property>
+                <style>
+                  <class name="dim-label" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkRevealer" id="revealer">
+            <child>
+              <object class="GtkGrid">
+                <property name="hexpand">True</property>
+
+                <child>
+                  <object class="GtkListBox" id="comboList">
+                    <property name="activate-on-single-click">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="selection-mode">none</property>
+                    <style>
+                      <class name="combos" />
+                    </style>
+                    <signal name="row-activated"
+                            handler="_onRowActivated" />
+                    <layout>
+                      <property name="row">0</property>
+                      <property name="column">0</property>
+                      <property name="column-span">2</property>
+                    </layout>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkButton" id="resetButton">
+                    <property name="label" translatable="yes">Reset</property>
+                    <property name="action-name">keybinding.reset</property>
+                    <property name="halign">start</property>
+                    <property name="margin-start">12px</property>
+                    <property name="margin-top">8px</property>
+                    <property name="margin-bottom">8px</property>
+                    <layout>
+                      <property name="row">1</property>
+                      <property name="column">0</property>
+                    </layout>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkButton" id="addButton">
+                    <property name="label" translatable="yes">Add shortcut…</property>
+                    <property name="action-name">keybinding.add</property>
+                    <property name="hexpand">True</property>
+                    <property name="halign">end</property>
+                    <property name="margin-top">8px</property>
+                    <property name="margin-end">12px</property>
+                    <property name="margin-bottom">8px</property>
+
+                    <layout>
+                      <property name="row">1</property>
+                      <property name="column">1</property>
+                    </layout>
+                    <style>
+                      <class name="suggested-action" />
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/Settings.ui
+++ b/Settings.ui
@@ -17,7 +17,6 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkImage" id="image1">
-    <property name="visible">True</property>
     <property name="focusable">False</property>
     <property name="icon_name"></property>
   </object>
@@ -46,35 +45,49 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkNotebook" id="paperwm_settings">
-    <property name="visible">True</property>
-    <property name="can_focus">True</property>
+  <object class="GtkStackSwitcher" id="switcher">
+    <property name="stack">paperwm_settings</property>
+  </object>
+  <object class="GtkStack" id="paperwm_settings">
+    <property name="transition-type">crossfade</property>
+    <property name="vexpand">True</property>
     <child>
-      <object class="GtkBox" id="general">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="margin_start">24</property>
-        <property name="margin_end">24</property>
-        <property name="margin_top">24</property>
-        <property name="margin_bottom">24</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">12</property>
-        <child>
-          <object class="GtkFrame" id="gaps-and-margins">
-            <property name="visible">True</property>
-            <property name="focusable">False</property>
+      <object class="GtkStackPage">
+        <property name="name">general</property>
+        <property name="title" translatable="yes">General</property>
+        <property name="child">
+          <object class="GtkBox" id="general">
+            <property name="halign">center</property>
+            <property name="margin_start">36</property>
+            <property name="margin_end">36</property>
+            <property name="margin_top">36</property>
+            <property name="margin_bottom">36</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="halign">start</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Gaps and margins</property>
+                <attributes>
+                  <attribute name="weight" value="bold" />
+                </attributes>
+              </object>
+            </child>
             <child>
               <object class="GtkListBox">
-                <property name="visible">True</property>
                 <property name="focusable">False</property>
                 <property name="selection_mode">none</property>
+                <property name="margin-bottom">24</property>
+                <style>
+                  <class name="frame" />
+                </style>
                 <child>
                   <object class="GtkListBoxRow" id="general_row">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid2">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -83,7 +96,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="workspace_label2">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Gap between windows</property>
@@ -96,7 +108,6 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="window_gap_spin">
-                            <property name="visible">True</property>
                             <property name="width_chars">2</property>
                             <property name="max_width_chars">2</property>
                             <property name="adjustment">window_gap</property>
@@ -115,12 +126,11 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow" id="general_row1">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
 
                     <child>
                       <object class="GtkGrid" id="workspace_grid1">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="tooltip_text" translatable="yes">The minimum margin to the left and right monitor edge</property>
                         <property name="margin_start">12</property>
@@ -130,7 +140,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Horizontal margin</property>
@@ -143,7 +152,6 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="hmargin_spinner">
-                            <property name="visible">True</property>
                             <property name="width_chars">2</property>
                             <property name="max_width_chars">2</property>
                             <property name="text" translatable="yes">0</property>
@@ -163,11 +171,10 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow" id="general_row2">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid5">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -176,7 +183,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Top margin</property>
@@ -189,7 +195,6 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="top_margin_spinner">
-                            <property name="visible">True</property>
                             <property name="width_chars">2</property>
                             <property name="max_width_chars">2</property>
                             <property name="text" translatable="yes">0</property>
@@ -209,11 +214,10 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow" id="general_row_3">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid6">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -222,7 +226,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Bottom margin</property>
@@ -235,7 +238,6 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="bottom_margin_spinner">
-                            <property name="visible">True</property>
                             <property name="width_chars">2</property>
                             <property name="max_width_chars">2</property>
                             <property name="text" translatable="yes">0</property>
@@ -255,38 +257,30 @@
                 </child>
               </object>
             </child>
-            <child type="label">
+            <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="focusable">False</property>
-                <property name="margin_start">6</property>
-                <property name="margin_end">6</property>
-                <property name="margin_top">6</property>
-                <property name="margin_bottom">6</property>
-                <property name="label" translatable="yes">Gaps and margins</property>
+                <property name="halign">start</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Three-finger swipes</property>
                 <attributes>
-                  <attribute name="weight" value="bold"></attribute>
+                  <attribute name="weight" value="bold" />
                 </attributes>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFrame" id="touchpad">
-            <property name="visible">True</property>
-            <property name="focusable">False</property>
             <child>
               <object class="GtkListBox">
-                <property name="visible">True</property>
                 <property name="focusable">False</property>
                 <property name="selection_mode">none</property>
+                <property name="margin-bottom">24</property>
+                <style>
+                  <class name="frame" />
+                </style>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid7">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -296,7 +290,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="workspace_label1">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Horizontal sensitivity</property>
@@ -309,7 +302,6 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="horizontal-sensitivity">
-                            <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="editable">True</property>
                             <property name="width_chars">2</property>
@@ -328,7 +320,6 @@
                         </child>
                         <child>
                           <object class="GtkLabel" id="workspace_label3">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Horizontal friction</property>
@@ -341,7 +332,6 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="horizontal-friction">
-                            <property name="visible">True</property>
                             <property name="width_chars">2</property>
                             <property name="max_width_chars">2</property>
                             <property name="text" translatable="yes">0,0</property>
@@ -362,11 +352,10 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid9">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -376,7 +365,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="workspace_label4">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Vertical sensitivity</property>
@@ -389,7 +377,6 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="vertical-sensitivity">
-                            <property name="visible">True</property>
                             <property name="width_chars">2</property>
                             <property name="max_width_chars">2</property>
                             <property name="text" translatable="yes">0</property>
@@ -406,7 +393,6 @@
                         </child>
                         <child>
                           <object class="GtkLabel" id="workspace_label6">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Vertical friction</property>
@@ -419,7 +405,6 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="vertical-friction">
-                            <property name="visible">True</property>
                             <property name="width_chars">2</property>
                             <property name="max_width_chars">2</property>
                             <property name="text" translatable="yes">0,0</property>
@@ -440,36 +425,29 @@
                 </child>
               </object>
             </child>
-            <child type="label">
+            <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="focusable">False</property>
-                <property name="margin_top">6</property>
-                <property name="margin_bottom">6</property>
-                <property name="label" translatable="yes">Three finger swipes</property>
+                <property name="halign">start</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Toggles</property>
                 <attributes>
-                  <attribute name="weight" value="bold"></attribute>
+                  <attribute name="weight" value="bold" />
                 </attributes>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFrame" id="general-toggles">
-            <property name="visible">True</property>
-            <property name="focusable">False</property>
             <child>
               <object class="GtkListBox">
-                <property name="visible">True</property>
                 <property name="focusable">False</property>
                 <property name="selection_mode">none</property>
+                <style>
+                  <class name="frame" />
+                </style>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid10">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -478,7 +456,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="scratch_in_overview_label">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Show scratch windows in overview</property>
@@ -491,7 +468,6 @@
                         </child>
                         <child>
                           <object class="GtkComboBoxText" id="scratch-in-overview">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">0</property>
                             <items>
@@ -511,11 +487,10 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid4">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -524,7 +499,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="override_hot_corner_label">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Disable hot corner</property>
@@ -537,7 +511,6 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="override-hot-corner">
-                            <property name="visible">True</property>
                             <layout>
                               <property name="column">1</property>
                               <property name="row">0</property>
@@ -550,11 +523,10 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid8">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -563,7 +535,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="topbar_follow_focus_label">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Make topbar follow monitor focus</property>
@@ -576,7 +547,6 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="topbar-follow-focus">
-                            <property name="visible">True</property>
                             <layout>
                               <property name="column">1</property>
                               <property name="row">0</property>
@@ -589,58 +559,48 @@
                 </child>
               </object>
             </child>
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStackPage">
+        <property name="name">workspaces</property>
+        <property name="title" translatable="yes">Workspaces</property>
+        <property name="child">
+          <object class="GtkBox" id="workspaces">
+            <property name="focusable">False</property>
+            <property name="halign">center</property>
+            <property name="margin_start">36</property>
+            <property name="margin_end">36</property>
+            <property name="margin_top">36</property>
+            <property name="margin_bottom">36</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
             <child type="label">
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="focusable">False</property>
-                <property name="margin_start">6</property>
-                <property name="margin_end">6</property>
-                <property name="margin_top">6</property>
-                <property name="margin_bottom">6</property>
-                <property name="label" translatable="yes">Toggles</property>
+                <property name="halign">start</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">All workspaces</property>
                 <attributes>
                   <attribute name="weight" value="bold"></attribute>
                 </attributes>
               </object>
             </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child type="tab">
-      <object class="GtkLabel" id="general_tab">
-        <property name="visible">True</property>
-        <property name="focusable">False</property>
-        <property name="label" translatable="yes">_General</property>
-        <property name="use_underline">1</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="workspaces">
-        <property name="visible">True</property>
-        <property name="focusable">False</property>
-        <property name="margin_start">24</property>
-        <property name="margin_end">24</property>
-        <property name="margin_top">24</property>
-        <property name="margin_bottom">24</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">24</property>
-        <child>
-          <object class="GtkFrame" id="workspace_frame_default_background">
-            <property name="visible">True</property>
-            <property name="focusable">False</property>
             <child>
               <object class="GtkListBox">
-                <property name="visible">True</property>
                 <property name="focusable">False</property>
                 <property name="selection_mode">none</property>
+                <property name="margin_bottom">24</property>
+                <style>
+                  <class name="frame" />
+                </style>
                 <child>
                   <object class="GtkListBoxRow" id="workspace_default_background_row">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_default_background_grid">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="tooltip_text" translatable="yes">Only supports static backgrounds</property>
                         <property name="margin_start">12</property>
@@ -650,7 +610,6 @@
                         <property name="column_spacing">24</property>
                         <child>
                           <object class="GtkLabel" id="workspace_default_background_label">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Use default GNOME Shell background</property>
@@ -663,7 +622,6 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="use-default-background">
-                            <property name="visible">True</property>
                             <property name="valign">center</property>
                             <layout>
                               <property name="column">2</property>
@@ -673,7 +631,6 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="gnome-background-panel">
-                            <property name="visible">True</property>
                             <property name="receives_default">1</property>
                             <property name="tooltip_text" translatable="yes">Launch gnome background picker</property>
                             <property name="icon-name">org.gnome.Settings-symbolic</property>
@@ -691,36 +648,27 @@
             </child>
             <child type="label">
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="focusable">False</property>
-                <property name="margin_start">6</property>
-                <property name="margin_end">6</property>
-                <property name="margin_top">6</property>
-                <property name="margin_bottom">6</property>
-                <property name="label" translatable="yes">All workspaces</property>
+                <property name="halign">start</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Per workspace</property>
                 <attributes>
                   <attribute name="weight" value="bold"></attribute>
                 </attributes>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFrame" id="workspace_frame_workspace">
-            <property name="visible">True</property>
-            <property name="focusable">False</property>
             <child>
               <object class="GtkListBox">
-                <property name="visible">True</property>
                 <property name="focusable">False</property>
                 <property name="selection_mode">none</property>
+                <style>
+                  <class name="frame" />
+                </style>
                 <child>
                   <object class="GtkListBoxRow" id="workspace_list_row">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <child>
                       <object class="GtkGrid" id="workspace_grid">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <property name="margin_start">12</property>
                         <property name="margin_end">12</property>
@@ -729,7 +677,6 @@
                         <property name="column_spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="workspace_label">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Configure workspace</property>
@@ -742,7 +689,6 @@
                         </child>
                         <child>
                           <object class="GtkComboBoxText" id="workspace_combo_text">
-                            <property name="visible">True</property>
                             <property name="focusable">False</property>
                             <property name="valign">center</property>
                             <layout>
@@ -757,13 +703,12 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="visible">True</property>
+                    <property name="activatable">False</property>
                     <property name="focusable">False</property>
                     <property name="width_request">100</property>
                     <property name="height_request">80</property>
                     <child>
                       <object class="GtkStack" id="workspace_stack">
-                        <property name="visible">True</property>
                         <property name="focusable">False</property>
                         <child>
                           <placeholder/>
@@ -774,103 +719,76 @@
                 </child>
               </object>
             </child>
-            <child type="label">
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="focusable">False</property>
-                <property name="margin_start">6</property>
-                <property name="margin_end">6</property>
-                <property name="margin_top">6</property>
-                <property name="margin_bottom">6</property>
-                <property name="label" translatable="yes">Per workspace</property>
-                <attributes>
-                  <attribute name="weight" value="bold"></attribute>
-                </attributes>
-              </object>
-            </child>
           </object>
-        </child>
-      </object>
-    </child>
-    <child type="tab">
-      <object class="GtkLabel" id="workspaces_tab">
-        <property name="visible">True</property>
-        <property name="focusable">False</property>
-        <property name="label" translatable="yes">_Workspaces</property>
-        <property name="use_underline">1</property>
+        </property>
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="focusable">False</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkSearchEntry" id="keybinding_search">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="hscrollbar_policy">never</property>
+      <object class="GtkStackPage">
+        <property name="name">keybindings</property>
+        <property name="title" translatable="yes">Keybindings</property>
+        <property name="child">
+          <object class="GtkBox">
+            <property name="focusable">False</property>
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkViewport">
-                <property name="visible">True</property>
-                <property name="focusable">False</property>
+              <object class="GtkSearchEntry" id="keybinding_search">
+                <property name="can_focus">True</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="hscrollbar_policy">never</property>
                 <child>
-                  <object class="GtkBox" id="keybindings">
-                    <property name="visible">True</property>
+                  <object class="GtkViewport">
                     <property name="focusable">False</property>
-                    <property name="margin_start">24</property>
-                    <property name="margin_end">24</property>
-                    <property name="margin_top">24</property>
-                    <property name="margin_bottom">24</property>
-                    <property name="vexpand">1</property>
-                    <property name="orientation">vertical</property>
                     <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
+                      <object class="GtkBox" id="keybindings">
+                        <property name="focusable">False</property>
+                        <property name="margin_start">24</property>
+                        <property name="margin_end">24</property>
+                        <property name="margin_top">24</property>
+                        <property name="margin_bottom">24</property>
+                        <property name="vexpand">1</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
                     </child>
                   </object>
                 </child>
               </object>
             </child>
           </object>
-        </child>
+        </property>
       </object>
     </child>
-    <child type="tab">
-      <object class="GtkLabel" id="keybindings_tab">
-        <property name="visible">True</property>
-        <property name="focusable">False</property>
-        <property name="label" translatable="yes">_Keybindings</property>
-        <property name="use_underline">1</property>
-      </object>
-    </child>
+  </object>
+  <object class="GtkPopover" id="about_popover">
     <child>
       <object class="GtkBox" id="about">
-        <property name="visible">True</property>
         <property name="focusable">False</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">12</property>
+        <property name="margin-start">12</property>
+        <property name="margin-end">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
+        <property name="spacing">6</property>
         <child>
           <object class="GtkImage" id="extension_logo">
-            <property name="visible">True</property>
             <property name="focusable">False</property>
-            <property name="margin_top">15</property>
             <property name="file">resources/logo.png</property>
           </object>
         </child>
         <child>
           <object class="GtkLabel" id="extension_name">
-            <property name="visible">True</property>
             <property name="focusable">False</property>
             <property name="label" translatable="yes">&lt;b&gt;PaperWM&lt;/b&gt;</property>
             <property name="use_markup">1</property>
@@ -879,7 +797,6 @@
         </child>
         <child>
           <object class="GtkLabel" id="extension_version">
-            <property name="visible">True</property>
             <property name="focusable">False</property>
             <property name="label" translatable="yes">$VERSION</property>
             <property name="use_markup">1</property>
@@ -888,7 +805,6 @@
         </child>
         <child>
           <object class="GtkLabel" id="extension_description">
-            <property name="visible">True</property>
             <property name="focusable">False</property>
             <property name="label" translatable="yes">Tiled scrollable window manager extension for Gnome Shell</property>
             <property name="justify">center</property>
@@ -897,7 +813,6 @@
         </child>
         <child>
           <object class="GtkLinkButton" id="homepage_link">
-            <property name="visible">True</property>
             <property name="label" translatable="yes">Webpage</property>
             <property name="receives_default">1</property>
             <property name="uri">https://github.com/paperwm/PaperWM</property>
@@ -905,13 +820,9 @@
         </child>
       </object>
     </child>
-    <child type="tab">
-      <object class="GtkLabel" id="about_tab">
-        <property name="visible">True</property>
-        <property name="focusable">False</property>
-        <property name="label" translatable="yes">_About</property>
-        <property name="use_underline">1</property>
-      </object>
-    </child>
+  </object>
+  <object class="GtkMenuButton" id="about_button">
+    <property name="popover">about_popover</property>
+    <property name="icon-name">dialog-information-symbolic</property>
   </object>
 </interface>

--- a/Settings.ui
+++ b/Settings.ui
@@ -742,53 +742,7 @@
         <property name="name">keybindings</property>
         <property name="title" translatable="yes">Keybindings</property>
         <property name="child">
-          <object class="GtkBox">
-            <property name="focusable">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkSearchBar">
-                <property name="hexpand">True</property>
-                <property name="search_mode_enabled">True</property>
-                <property name="child">
-                  <object class="GtkSearchEntry" id="keybinding_search">
-                    <property name="can_focus">True</property>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="hscrollbar_policy">never</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="focusable">False</property>
-                    <child>
-                      <object class="GtkBox" id="keybindings">
-                        <property name="focusable">False</property>
-                        <property name="margin_start">36</property>
-                        <property name="margin_end">36</property>
-                        <property name="margin_top">36</property>
-                        <property name="margin_bottom">36</property>
-                        <property name="vexpand">1</property>
-                        <property name="halign">center</property>
-                        <property name="width_request">480</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
+          <object class="KeybindingsPane" />
         </property>
       </object>
     </child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -64,6 +64,7 @@
             <property name="margin_bottom">36</property>
             <property name="orientation">vertical</property>
             <property name="spacing">12</property>
+            <property name="width_request">480</property>
             <child>
               <object class="GtkLabel">
                 <property name="halign">start</property>
@@ -577,6 +578,7 @@
             <property name="margin_bottom">36</property>
             <property name="orientation">vertical</property>
             <property name="spacing">12</property>
+            <property name="width_request">480</property>
             <child type="label">
               <object class="GtkLabel">
                 <property name="halign">start</property>
@@ -705,6 +707,18 @@
                   <object class="GtkListBoxRow">
                     <property name="activatable">False</property>
                     <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkSeparator">
+                        <property name="orientation">horizontal</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="activatable">False</property>
+                    <property name="focusable">False</property>
                     <property name="width_request">100</property>
                     <property name="height_request">80</property>
                     <child>
@@ -732,8 +746,14 @@
             <property name="focusable">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkSearchEntry" id="keybinding_search">
-                <property name="can_focus">True</property>
+              <object class="GtkSearchBar">
+                <property name="hexpand">True</property>
+                <property name="search_mode_enabled">True</property>
+                <property name="child">
+                  <object class="GtkSearchEntry" id="keybinding_search">
+                    <property name="can_focus">True</property>
+                  </object>
+                </property>
               </object>
             </child>
             <child>
@@ -745,11 +765,13 @@
                     <child>
                       <object class="GtkBox" id="keybindings">
                         <property name="focusable">False</property>
-                        <property name="margin_start">24</property>
-                        <property name="margin_end">24</property>
-                        <property name="margin_top">24</property>
-                        <property name="margin_bottom">24</property>
+                        <property name="margin_start">36</property>
+                        <property name="margin_end">36</property>
+                        <property name="margin_top">36</property>
+                        <property name="margin_bottom">36</property>
                         <property name="vexpand">1</property>
+                        <property name="halign">center</property>
+                        <property name="width_request">480</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <placeholder/>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <interface>
   <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="horizontal-friction-adjustment">
@@ -17,8 +17,9 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkImage" id="image1">
-    <property name="can_focus">0</property>
-    <property name="icon_name">org.gnome.Settings-symbolic</property>
+    <property name="visible">True</property>
+    <property name="focusable">False</property>
+    <property name="icon_name"></property>
   </object>
   <object class="GtkAdjustment" id="vertical-friction-adjustment">
     <property name="upper">10</property>
@@ -46,787 +47,870 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkNotebook" id="paperwm_settings">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
     <child>
-      <object class="GtkNotebookPage">
-        <property name="child">
-          <object class="GtkBox" id="general">
-            <property name="can_focus">0</property>
-            <property name="margin-start">24</property>
-            <property name="margin-end">24</property>
-            <property name="margin_top">24</property>
-            <property name="margin_bottom">24</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
+      <object class="GtkBox" id="general">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="margin_start">24</property>
+        <property name="margin_end">24</property>
+        <property name="margin_top">24</property>
+        <property name="margin_bottom">24</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
+        <child>
+          <object class="GtkFrame" id="gaps-and-margins">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
             <child>
-              <object class="GtkFrame" id="gaps-and-margins">
-                <property name="can_focus">0</property>
+              <object class="GtkListBox">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="selection_mode">none</property>
                 <child>
-                      <object class="GtkListBox">
-                        <property name="can_focus">0</property>
-                        <property name="selection_mode">none</property>
+                  <object class="GtkListBoxRow" id="general_row">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid2">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
                         <child>
-                          <object class="GtkListBoxRow" id="general_row">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid2">
-                                <property name="can_focus">0</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel" id="workspace_label2">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Gap between windows</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="window_gap_spin">
-                                    <property name="width_chars">2</property>
-                                    <property name="max_width_chars">2</property>
-                                    <property name="adjustment">window_gap</property>
-                                    <property name="snap_to_ticks">1</property>
-                                    <property name="numeric">1</property>
-                                    <property name="update_policy">if-valid</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                        <child>
-                          <object class="GtkListBoxRow" id="general_row1">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid1">
-                                <property name="can_focus">0</property>
-                                <property name="tooltip_text" translatable="yes">The minimum margin to the left and right monitor edge</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Horizontal margin</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="hmargin_spinner">
-                                    <property name="width_chars">2</property>
-                                    <property name="max_width_chars">2</property>
-                                    <property name="text" translatable="yes">0</property>
-                                    <property name="adjustment">horizontal_margin</property>
-                                    <property name="snap_to_ticks">1</property>
-                                    <property name="numeric">1</property>
-                                    <property name="update_policy">if-valid</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
+                          <object class="GtkLabel" id="workspace_label2">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Gap between windows</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
                         </child>
                         <child>
-                          <object class="GtkListBoxRow" id="general_row2">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid5">
-                                <property name="can_focus">0</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Top margin</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="top_margin_spinner">
-                                    <property name="width_chars">2</property>
-                                    <property name="max_width_chars">2</property>
-                                    <property name="text" translatable="yes">0</property>
-                                    <property name="adjustment">vertical_margin</property>
-                                    <property name="snap_to_ticks">1</property>
-                                    <property name="numeric">1</property>
-                                    <property name="update_policy">if-valid</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkListBoxRow" id="general_row_3">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid6">
-                                <property name="can_focus">0</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Bottom margin</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="bottom_margin_spinner">
-                                    <property name="width_chars">2</property>
-                                    <property name="max_width_chars">2</property>
-                                    <property name="text" translatable="yes">0</property>
-                                    <property name="adjustment">vertical_margin_bottom</property>
-                                    <property name="snap_to_ticks">1</property>
-                                    <property name="numeric">1</property>
-                                    <property name="update_policy">if-valid</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
+                          <object class="GtkSpinButton" id="window_gap_spin">
+                            <property name="visible">True</property>
+                            <property name="width_chars">2</property>
+                            <property name="max_width_chars">2</property>
+                            <property name="adjustment">window_gap</property>
+                            <property name="snap_to_ticks">1</property>
+                            <property name="numeric">1</property>
+                            <property name="update_policy">if-valid</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
                         </child>
                       </object>
                     </child>
                   </object>
                 </child>
-                <child type="label">
-                  <object class="GtkLabel">
-                    <property name="can_focus">0</property>
-                    <property name="margin-start">6</property>
-                    <property name="margin-end">6</property>
-                    <property name="margin_top">6</property>
-                    <property name="margin_bottom">6</property>
-                    <property name="label" translatable="yes">Gaps and margins</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"></attribute>
-                    </attributes>
+                <child>
+                  <object class="GtkListBoxRow" id="general_row1">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid1">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="tooltip_text" translatable="yes">The minimum margin to the left and right monitor edge</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Horizontal margin</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="hmargin_spinner">
+                            <property name="visible">True</property>
+                            <property name="width_chars">2</property>
+                            <property name="max_width_chars">2</property>
+                            <property name="text" translatable="yes">0</property>
+                            <property name="adjustment">horizontal_margin</property>
+                            <property name="snap_to_ticks">1</property>
+                            <property name="numeric">1</property>
+                            <property name="update_policy">if-valid</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow" id="general_row2">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid5">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Top margin</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="top_margin_spinner">
+                            <property name="visible">True</property>
+                            <property name="width_chars">2</property>
+                            <property name="max_width_chars">2</property>
+                            <property name="text" translatable="yes">0</property>
+                            <property name="adjustment">vertical_margin</property>
+                            <property name="snap_to_ticks">1</property>
+                            <property name="numeric">1</property>
+                            <property name="update_policy">if-valid</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow" id="general_row_3">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid6">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Bottom margin</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="bottom_margin_spinner">
+                            <property name="visible">True</property>
+                            <property name="width_chars">2</property>
+                            <property name="max_width_chars">2</property>
+                            <property name="text" translatable="yes">0</property>
+                            <property name="adjustment">vertical_margin_bottom</property>
+                            <property name="snap_to_ticks">1</property>
+                            <property name="numeric">1</property>
+                            <property name="update_policy">if-valid</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
             </child>
-            <child>
-              <object class="GtkFrame" id="touchpad">
-                <property name="can_focus">0</property>
-                <child>
-                      <object class="GtkListBox">
-                        <property name="can_focus">0</property>
-                        <property name="selection_mode">none</property>
-                        <child>
-                          <object class="GtkListBoxRow">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid7">
-                                <property name="can_focus">0</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="row_spacing">12</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel" id="workspace_label1">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Horizontal sensitivity</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="horizontal-sensitivity">
-                                    <property name="width_chars">2</property>
-                                    <property name="max_width_chars">2</property>
-                                    <property name="text" translatable="yes">0</property>
-                                    <property name="adjustment">horizontal-sensitivity-adjustment</property>
-                                    <property name="digits">1</property>
-                                    <property name="snap_to_ticks">1</property>
-                                    <property name="numeric">1</property>
-                                    <property name="update_policy">if-valid</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="workspace_label3">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Horizontal friction</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="horizontal-friction">
-                                    <property name="width_chars">2</property>
-                                    <property name="max_width_chars">2</property>
-                                    <property name="text" translatable="yes">0,0</property>
-                                    <property name="adjustment">horizontal-friction-adjustment</property>
-                                    <property name="digits">1</property>
-                                    <property name="snap_to_ticks">1</property>
-                                    <property name="numeric">1</property>
-                                    <property name="update_policy">if-valid</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                        <child>
-                          <object class="GtkListBoxRow">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid9">
-                                <property name="can_focus">0</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="row_spacing">12</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel" id="workspace_label4">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Vertical sensitivity</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="vertical-sensitivity">
-                                    <property name="width_chars">2</property>
-                                    <property name="max_width_chars">2</property>
-                                    <property name="text" translatable="yes">0</property>
-                                    <property name="adjustment">vertical-sensitivity-adjustment</property>
-                                    <property name="digits">1</property>
-                                    <property name="snap_to_ticks">1</property>
-                                    <property name="numeric">1</property>
-                                    <property name="update_policy">if-valid</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="workspace_label6">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Vertical friction</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="vertical-friction">
-                                    <property name="width_chars">2</property>
-                                    <property name="max_width_chars">2</property>
-                                    <property name="text" translatable="yes">0,0</property>
-                                    <property name="adjustment">vertical-friction-adjustment</property>
-                                    <property name="digits">1</property>
-                                    <property name="snap_to_ticks">1</property>
-                                    <property name="numeric">1</property>
-                                    <property name="update_policy">if-valid</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel">
-                    <property name="can_focus">0</property>
-                    <property name="margin_top">6</property>
-                    <property name="margin_bottom">6</property>
-                    <property name="label" translatable="yes">Three finger swipes</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"></attribute>
-                    </attributes>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFrame" id="general-toggles">
-                <property name="can_focus">0</property>
-                <child>
-                      <object class="GtkListBox">
-                        <property name="can_focus">0</property>
-                        <property name="selection_mode">none</property>
-                        <child>
-                          <object class="GtkListBoxRow">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid10">
-                                <property name="can_focus">0</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel" id="scratch_in_overview_label">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Show scratch windows in overview</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBoxText" id="scratch-in-overview">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">0</property>
-                                    <items>
-                                      <item id="always" translatable="yes">Always</item>
-                                      <item id="only" translatable="yes">Only</item>
-                                      <item id="never" translatable="yes">Never</item>
-                                    </items>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                        <child>
-                          <object class="GtkListBoxRow">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid4">
-                                <property name="can_focus">0</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel" id="override_hot_corner_label">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Disable hot corner</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSwitch" id="override-hot-corner">
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkListBoxRow">
-                            <property name="child">
-                              <object class="GtkGrid" id="workspace_grid8">
-                                <property name="can_focus">0</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <property name="column_spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel" id="topbar_follow_focus_label">
-                                    <property name="can_focus">0</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Make topbar follow monitor focus</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSwitch" id="topbar-follow-focus">
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel">
-                    <property name="can_focus">0</property>
-                    <property name="margin-start">6</property>
-                    <property name="margin-end">6</property>
-                    <property name="margin_top">6</property>
-                    <property name="margin_bottom">6</property>
-                    <property name="label" translatable="yes">Toggles</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"></attribute>
-                    </attributes>
-                  </object>
-                </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="margin_start">6</property>
+                <property name="margin_end">6</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
+                <property name="label" translatable="yes">Gaps and margins</property>
+                <attributes>
+                  <attribute name="weight" value="bold"></attribute>
+                </attributes>
               </object>
             </child>
           </object>
-        </property>
-        <property name="tab">
-          <object class="GtkLabel" id="general_tab">
-            <property name="can_focus">0</property>
-            <property name="label" translatable="yes">_General</property>
-            <property name="use_underline">1</property>
+        </child>
+        <child>
+          <object class="GtkFrame" id="touchpad">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
+            <child>
+              <object class="GtkListBox">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="selection_mode">none</property>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid7">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="row_spacing">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="workspace_label1">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Horizontal sensitivity</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="horizontal-sensitivity">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="editable">True</property>
+                            <property name="width_chars">2</property>
+                            <property name="max_width_chars">2</property>
+                            <property name="text" translatable="yes">0</property>
+                            <property name="adjustment">horizontal-sensitivity-adjustment</property>
+                            <property name="digits">1</property>
+                            <property name="snap_to_ticks">1</property>
+                            <property name="numeric">1</property>
+                            <property name="update_policy">if-valid</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="workspace_label3">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Horizontal friction</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="horizontal-friction">
+                            <property name="visible">True</property>
+                            <property name="width_chars">2</property>
+                            <property name="max_width_chars">2</property>
+                            <property name="text" translatable="yes">0,0</property>
+                            <property name="adjustment">horizontal-friction-adjustment</property>
+                            <property name="digits">1</property>
+                            <property name="snap_to_ticks">1</property>
+                            <property name="numeric">1</property>
+                            <property name="update_policy">if-valid</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid9">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="row_spacing">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="workspace_label4">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Vertical sensitivity</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="vertical-sensitivity">
+                            <property name="visible">True</property>
+                            <property name="width_chars">2</property>
+                            <property name="max_width_chars">2</property>
+                            <property name="text" translatable="yes">0</property>
+                            <property name="adjustment">vertical-sensitivity-adjustment</property>
+                            <property name="digits">1</property>
+                            <property name="snap_to_ticks">1</property>
+                            <property name="numeric">1</property>
+                            <property name="update_policy">if-valid</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="workspace_label6">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Vertical friction</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="vertical-friction">
+                            <property name="visible">True</property>
+                            <property name="width_chars">2</property>
+                            <property name="max_width_chars">2</property>
+                            <property name="text" translatable="yes">0,0</property>
+                            <property name="adjustment">vertical-friction-adjustment</property>
+                            <property name="digits">1</property>
+                            <property name="snap_to_ticks">1</property>
+                            <property name="numeric">1</property>
+                            <property name="update_policy">if-valid</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
+                <property name="label" translatable="yes">Three finger swipes</property>
+                <attributes>
+                  <attribute name="weight" value="bold"></attribute>
+                </attributes>
+              </object>
+            </child>
           </object>
-        </property>
+        </child>
+        <child>
+          <object class="GtkFrame" id="general-toggles">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
+            <child>
+              <object class="GtkListBox">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="selection_mode">none</property>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid10">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="scratch_in_overview_label">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Show scratch windows in overview</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="scratch-in-overview">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">0</property>
+                            <items>
+                              <item id="always" translatable="yes">Always</item>
+                              <item id="only" translatable="yes">Only</item>
+                              <item id="never" translatable="yes">Never</item>
+                            </items>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid4">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="override_hot_corner_label">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Disable hot corner</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="override-hot-corner">
+                            <property name="visible">True</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <child>
+                      <object class="GtkGrid" id="workspace_grid8">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="topbar_follow_focus_label">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Make topbar follow monitor focus</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="topbar-follow-focus">
+                            <property name="visible">True</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="margin_start">6</property>
+                <property name="margin_end">6</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
+                <property name="label" translatable="yes">Toggles</property>
+                <attributes>
+                  <attribute name="weight" value="bold"></attribute>
+                </attributes>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child type="tab">
+      <object class="GtkLabel" id="general_tab">
+        <property name="visible">True</property>
+        <property name="focusable">False</property>
+        <property name="label" translatable="yes">_General</property>
+        <property name="use_underline">1</property>
       </object>
     </child>
     <child>
-      <object class="GtkNotebookPage">
-        <property name="position">1</property>
-        <property name="child">
-          <object class="GtkBox" id="workspaces">
-            <property name="can_focus">0</property>
-            <property name="margin-start">24</property>
-            <property name="margin-end">24</property>
-            <property name="margin_top">24</property>
-            <property name="margin_bottom">24</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">24</property>
+      <object class="GtkBox" id="workspaces">
+        <property name="visible">True</property>
+        <property name="focusable">False</property>
+        <property name="margin_start">24</property>
+        <property name="margin_end">24</property>
+        <property name="margin_top">24</property>
+        <property name="margin_bottom">24</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">24</property>
+        <child>
+          <object class="GtkFrame" id="workspace_frame_default_background">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
             <child>
-              <object class="GtkFrame" id="workspace_frame_default_background">
-                <property name="can_focus">0</property>
-                <property name="child">
-                  <object class="GtkListBox">
-                    <property name="can_focus">0</property>
-                    <property name="selection_mode">none</property>
+              <object class="GtkListBox">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="selection_mode">none</property>
+                <child>
+                  <object class="GtkListBoxRow" id="workspace_default_background_row">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
                     <child>
-                      <object class="GtkListBoxRow" id="workspace_default_background_row">
-                        <property name="child">
-                          <object class="GtkGrid" id="workspace_default_background_grid">
-                            <property name="can_focus">0</property>
-                            <property name="tooltip_text" translatable="yes">Only supports static backgrounds</property>
-                            <property name="margin-start">12</property>
-                            <property name="margin-end">12</property>
-                            <property name="margin_top">12</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="column_spacing">24</property>
-                            <child>
-                              <object class="GtkLabel" id="workspace_default_background_label">
-                                <property name="can_focus">0</property>
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Use default GNOME Shell background</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="use-default-background">
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">2</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="gnome-background-panel">
-                                <property name="receives_default">1</property>
-                                <property name="tooltip_text" translatable="yes">Launch gnome background picker</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
+                      <object class="GtkGrid" id="workspace_default_background_grid">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="tooltip_text" translatable="yes">Only supports static backgrounds</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">24</property>
+                        <child>
+                          <object class="GtkLabel" id="workspace_default_background_label">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Use default GNOME Shell background</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
-                        </property>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="use-default-background">
+                            <property name="visible">True</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">2</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="gnome-background-panel">
+                            <property name="visible">True</property>
+                            <property name="receives_default">1</property>
+                            <property name="tooltip_text" translatable="yes">Launch gnome background picker</property>
+                            <property name="icon-name">org.gnome.Settings-symbolic</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
                       </object>
                     </child>
-                  </object>
-                </property>
-                <child type="label">
-                  <object class="GtkLabel">
-                    <property name="can_focus">0</property>
-                    <property name="margin-start">6</property>
-                    <property name="margin-end">6</property>
-                    <property name="margin_top">6</property>
-                    <property name="margin_bottom">6</property>
-                    <property name="label" translatable="yes">All workspaces</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"></attribute>
-                    </attributes>
                   </object>
                 </child>
               </object>
             </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="margin_start">6</property>
+                <property name="margin_end">6</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
+                <property name="label" translatable="yes">All workspaces</property>
+                <attributes>
+                  <attribute name="weight" value="bold"></attribute>
+                </attributes>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame" id="workspace_frame_workspace">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
             <child>
-              <object class="GtkFrame" id="workspace_frame_workspace">
-                <property name="can_focus">0</property>
-                <property name="child">
-                  <object class="GtkListBox">
-                    <property name="can_focus">0</property>
-                    <property name="selection_mode">none</property>
+              <object class="GtkListBox">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="selection_mode">none</property>
+                <child>
+                  <object class="GtkListBoxRow" id="workspace_list_row">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
                     <child>
-                      <object class="GtkListBoxRow" id="workspace_list_row">
-                        <property name="child">
-                          <object class="GtkGrid" id="workspace_grid">
-                            <property name="can_focus">0</property>
-                            <property name="margin-start">12</property>
-                            <property name="margin-end">12</property>
-                            <property name="margin_top">12</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="column_spacing">32</property>
-                            <child>
-                              <object class="GtkLabel" id="workspace_label">
-                                <property name="can_focus">0</property>
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Configure workspace</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkComboBoxText" id="workspace_combo_text">
-                                <property name="can_focus">0</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
+                      <object class="GtkGrid" id="workspace_grid">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="workspace_label">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Configure workspace</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkListBoxRow">
-                        <property name="width_request">100</property>
-                        <property name="height_request">80</property>
-                        <property name="child">
-                          <object class="GtkStack" id="workspace_stack">
-                            <property name="can_focus">0</property>
-                            <child>
-                              <placeholder/>
-                            </child>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="workspace_combo_text">
+                            <property name="visible">True</property>
+                            <property name="focusable">False</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
-                        </property>
+                        </child>
                       </object>
                     </child>
                   </object>
-                </property>
-                <child type="label">
-                  <object class="GtkLabel">
-                    <property name="can_focus">0</property>
-                    <property name="margin-start">6</property>
-                    <property name="margin-end">6</property>
-                    <property name="margin_top">6</property>
-                    <property name="margin_bottom">6</property>
-                    <property name="label" translatable="yes">Per workspace</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"></attribute>
-                    </attributes>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <property name="width_request">100</property>
+                    <property name="height_request">80</property>
+                    <child>
+                      <object class="GtkStack" id="workspace_stack">
+                        <property name="visible">True</property>
+                        <property name="focusable">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <property name="margin_start">6</property>
+                <property name="margin_end">6</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
+                <property name="label" translatable="yes">Per workspace</property>
+                <attributes>
+                  <attribute name="weight" value="bold"></attribute>
+                </attributes>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child type="tab">
+      <object class="GtkLabel" id="workspaces_tab">
+        <property name="visible">True</property>
+        <property name="focusable">False</property>
+        <property name="label" translatable="yes">_Workspaces</property>
+        <property name="use_underline">1</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="focusable">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkSearchEntry" id="keybinding_search">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="hscrollbar_policy">never</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="focusable">False</property>
+                <child>
+                  <object class="GtkBox" id="keybindings">
+                    <property name="visible">True</property>
+                    <property name="focusable">False</property>
+                    <property name="margin_start">24</property>
+                    <property name="margin_end">24</property>
+                    <property name="margin_top">24</property>
+                    <property name="margin_bottom">24</property>
+                    <property name="vexpand">1</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
                   </object>
                 </child>
               </object>
             </child>
           </object>
-        </property>
-        <property name="tab">
-          <object class="GtkLabel" id="workspaces_tab">
-            <property name="can_focus">0</property>
-            <property name="label" translatable="yes">_Workspaces</property>
-            <property name="use_underline">1</property>
-          </object>
-        </property>
+        </child>
+      </object>
+    </child>
+    <child type="tab">
+      <object class="GtkLabel" id="keybindings_tab">
+        <property name="visible">True</property>
+        <property name="focusable">False</property>
+        <property name="label" translatable="yes">_Keybindings</property>
+        <property name="use_underline">1</property>
       </object>
     </child>
     <child>
-      <object class="GtkNotebookPage">
-        <property name="position">2</property>
-        <property name="child">
-          <object class="GtkBox">
-            <property name="can_focus">0</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkSearchEntry" id="keybinding_search">
-              </object>
-            </child>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="hscrollbar_policy">never</property>
-                <property name="child">
-                  <object class="GtkViewport">
-                    <property name="can_focus">0</property>
-                    <property name="child">
-                      <object class="GtkBox" id="keybindings">
-                        <property name="can_focus">0</property>
-                        <property name="margin-start">24</property>
-                        <property name="margin-end">24</property>
-                        <property name="margin_top">24</property>
-                        <property name="margin_bottom">24</property>
-                        <property name="vexpand">1</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                    </property>
-                  </object>
-                </property>
-              </object>
-            </child>
+      <object class="GtkBox" id="about">
+        <property name="visible">True</property>
+        <property name="focusable">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
+        <child>
+          <object class="GtkImage" id="extension_logo">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
+            <property name="margin_top">15</property>
+            <property name="file">resources/logo.png</property>
           </object>
-        </property>
-        <property name="tab">
-          <object class="GtkLabel" id="keybindings_tab">
-            <property name="can_focus">0</property>
-            <property name="label" translatable="yes">_Keybindings</property>
-            <property name="use_underline">1</property>
+        </child>
+        <child>
+          <object class="GtkLabel" id="extension_name">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
+            <property name="label" translatable="yes">&lt;b&gt;PaperWM&lt;/b&gt;</property>
+            <property name="use_markup">1</property>
+            <property name="justify">center</property>
           </object>
-        </property>
+        </child>
+        <child>
+          <object class="GtkLabel" id="extension_version">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
+            <property name="label" translatable="yes">$VERSION</property>
+            <property name="use_markup">1</property>
+            <property name="justify">center</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="extension_description">
+            <property name="visible">True</property>
+            <property name="focusable">False</property>
+            <property name="label" translatable="yes">Tiled scrollable window manager extension for Gnome Shell</property>
+            <property name="justify">center</property>
+            <property name="wrap">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLinkButton" id="homepage_link">
+            <property name="visible">True</property>
+            <property name="label" translatable="yes">Webpage</property>
+            <property name="receives_default">1</property>
+            <property name="uri">https://github.com/paperwm/PaperWM</property>
+          </object>
+        </child>
       </object>
     </child>
-    <child>
-      <object class="GtkNotebookPage">
-        <property name="position">3</property>
-        <property name="child">
-          <object class="GtkBox" id="about">
-            <property name="can_focus">0</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
-            <child>
-              <object class="GtkImage" id="extension_logo">
-                <property name="can_focus">0</property>
-                <property name="margin_top">15</property>
-                <property name="file">resources/logo.png</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="extension_name">
-                <property name="can_focus">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;PaperWM&lt;/b&gt;</property>
-                <property name="use_markup">1</property>
-                <property name="justify">center</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="extension_version">
-                <property name="can_focus">0</property>
-                <property name="label" translatable="yes">$VERSION</property>
-                <property name="use_markup">1</property>
-                <property name="justify">center</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="extension_description">
-                <property name="can_focus">0</property>
-                <property name="label" translatable="yes">Tiled scrollable window manager extension for Gnome Shell</property>
-                <property name="justify">center</property>
-                <property name="wrap">1</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLinkButton" id="homepage_link">
-                <property name="label" translatable="yes">Webpage</property>
-                <property name="receives_default">1</property>
-                <property name="uri">https://github.com/paperwm/PaperWM</property>
-              </object>
-            </child>
-          </object>
-        </property>
-        <property name="tab">
-          <object class="GtkLabel" id="about_tab">
-            <property name="can_focus">0</property>
-            <property name="label" translatable="yes">_About</property>
-            <property name="use_underline">1</property>
-          </object>
-        </property>
+    <child type="tab">
+      <object class="GtkLabel" id="about_tab">
+        <property name="visible">True</property>
+        <property name="focusable">False</property>
+        <property name="label" translatable="yes">_About</property>
+        <property name="use_underline">1</property>
       </object>
     </child>
   </object>

--- a/keybindings.js
+++ b/keybindings.js
@@ -505,7 +505,7 @@ function enableAction(action) {
 
     } else {
         if (keycomboMap[action.keycombo]) {
-            Utils.warn("Other action bound to", action.keystr, keycomboMap[action.keycombo].name)
+            Utils.warn("Other action bound to", action.keystr, keycomboMap[action.keycombo].name);
             return Meta.KeyBindingAction.NONE;
         }
 

--- a/prefs.js
+++ b/prefs.js
@@ -65,9 +65,10 @@ class SettingsWidget {
 
         this.builder = Gtk.Builder.new_from_file(Extension.path + '/Settings.ui');
 
-        this._notebook = this.builder.get_object('paperwm_settings');
-        this.widget = this._notebook;
-        this._notebook.page = selectedTab;
+        this.aboutButton = this.builder.get_object('about_button');
+        this.switcher = this.builder.get_object('switcher');
+        this.widget = this.builder.get_object('paperwm_settings');
+        this.widget.pages.select_item(selectedTab, true);
         this._backgroundFilter = new Gtk.FileFilter();
         this._backgroundFilter.add_pixbuf_formats();
 
@@ -772,7 +773,12 @@ function buildPrefsWidget() {
         selectedTab = 1;
     }
     let settings = new SettingsWidget(selectedTab, selectedWorkspace || 0);
-    let widget = settings.widget;
-    widget.show();
-    return widget;
+    GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+        let window = settings.widget.get_root();
+        let headerbar = window.get_titlebar();
+        headerbar.pack_start(settings.aboutButton);
+        headerbar.set_title_widget(settings.switcher);
+        return false;
+    });
+    return settings.widget;
 }

--- a/prefsKeybinding.js
+++ b/prefsKeybinding.js
@@ -1,0 +1,1060 @@
+'use strict';
+
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Gdk = imports.gi.Gdk;
+
+const ExtensionUtils = imports.misc.extensionUtils;
+const Extension = ExtensionUtils.getCurrentExtension();
+const Convenience = Extension.imports.convenience;
+const Settings = Extension.imports.settings;
+
+// TODO gettext translations
+const _ = s => s;
+
+const KEYBINDINGS_KEY = 'org.gnome.Shell.Extensions.PaperWM.Keybindings';
+
+const sections = {
+    windows: 'Windows',
+    workspaces: 'Workspaces',
+    monitors: 'Monitors',
+    scratch: 'Scratch layer',
+};
+
+const actions = {
+    windows: [
+        'new-window',
+        'close-window',
+        'switch-next',
+        'switch-previous',
+        'switch-left',
+        'switch-right',
+        'switch-up',
+        'switch-down',
+        'switch-first',
+        'switch-last',
+        'live-alt-tab',
+        'live-alt-tab-backward',
+        'move-left',
+        'move-right',
+        'move-up',
+        'move-down',
+        'slurp-in',
+        'barf-out',
+        'center-horizontally',
+        'paper-toggle-fullscreen',
+        'toggle-maximize-width',
+        'resize-h-inc',
+        'resize-h-dec',
+        'resize-w-inc',
+        'resize-w-dec',
+        'cycle-width',
+        'cycle-height',
+        'take-window',
+    ],
+    workspaces: [
+        'previous-workspace',
+        'previous-workspace-backward',
+        'move-previous-workspace',
+        'move-previous-workspace-backward',
+        'switch-up-workspace',
+        'switch-down-workspace',
+        'move-up-workspace',
+        'move-down-workspace',
+    ],
+    monitors: [
+        'switch-monitor-right',
+        'switch-monitor-left',
+        'switch-monitor-above',
+        'switch-monitor-below',
+        'move-monitor-right',
+        'move-monitor-left',
+        'move-monitor-above',
+        'move-monitor-below',
+    ],
+    scratch: [
+        'toggle-scratch-layer',
+        'toggle-scratch',
+        'toggle-scratch-window'
+    ],
+};
+
+const forbiddenKeyvals = [
+    Gdk.KEY_Home,
+    Gdk.KEY_Left,
+    Gdk.KEY_Up,
+    Gdk.KEY_Right,
+    Gdk.KEY_Down,
+    Gdk.KEY_Page_Up,
+    Gdk.KEY_Page_Down,
+    Gdk.KEY_End,
+    Gdk.KEY_Tab,
+    Gdk.KEY_KP_Enter,
+    Gdk.KEY_Return,
+    Gdk.KEY_Mode_switch
+];
+
+function isValidBinding(combo) {
+    if ((combo.mods == 0 || combo.mods == Gdk.ModifierType.SHIFT_MASK) && combo.keycode != 0) {
+        const keyval = combo.keyval;
+        if ((keyval >= Gdk.KEY_a && keyval <= Gdk.KEY_z)
+            || (keyval >= Gdk.KEY_A && keyval <= Gdk.KEY_Z)
+            || (keyval >= Gdk.KEY_0 && keyval <= Gdk.KEY_9)
+            || (keyval >= Gdk.KEY_kana_fullstop && keyval <= Gdk.KEY_semivoicedsound)
+            || (keyval >= Gdk.KEY_Arabic_comma && keyval <= Gdk.KEY_Arabic_sukun)
+            || (keyval >= Gdk.KEY_Serbian_dje && keyval <= Gdk.KEY_Cyrillic_HARDSIGN)
+            || (keyval >= Gdk.KEY_Greek_ALPHAaccent && keyval <= Gdk.KEY_Greek_omega)
+            || (keyval >= Gdk.KEY_hebrew_doublelowline && keyval <= Gdk.KEY_hebrew_taf)
+            || (keyval >= Gdk.KEY_Thai_kokai && keyval <= Gdk.KEY_Thai_lekkao)
+            || (keyval >= Gdk.KEY_Hangul_Kiyeog && keyval <= Gdk.KEY_Hangul_J_YeorinHieuh)
+            || (keyval == Gdk.KEY_space && combo.mods == 0)
+            || forbiddenKeyvals.includes(keyval)) {
+            return false;
+        }
+    }
+
+    // Allow Tab in addition to accelerators allowed by GTK
+    if (!Gtk.accelerator_valid(combo.keyval, combo.mods) &&
+        (combo.keyval != Gdk.KEY_Tab || combo.mods == 0)) {
+        return false;
+    }
+
+    return true;
+}
+
+function isEmptyBinding(combo) {
+    return combo.keyval == 0 && combo.mods == 0 && combo.keycode == 0;
+}
+
+const Combo = GObject.registerClass({
+    GTypeName: 'Combo',
+    Properties: {
+        keycode: GObject.ParamSpec.uint(
+            'keycode',
+            'Keycode',
+            'Key code',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            0,
+            GLib.MAXUINT32,
+            0
+        ),
+        keyval: GObject.ParamSpec.uint(
+            'keyval',
+            'Keyval',
+            'Key value',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            0,
+            GLib.MAXUINT32,
+            0
+        ),
+        mods: GObject.ParamSpec.uint(
+            'mods',
+            'Mods',
+            'Key modifiers',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            0,
+            GLib.MAXUINT32,
+            0
+        ),
+        keystr: GObject.ParamSpec.string(
+            'keystr',
+            'Keystr',
+            'Key string',
+            GObject.ParamFlags.READABLE,
+            null
+        ),
+        label: GObject.ParamSpec.string(
+            'label',
+            'Label',
+            'Key label',
+            GObject.ParamFlags.READABLE,
+            null
+        ),
+        disabled: GObject.ParamSpec.boolean(
+            'disabled',
+            'Disabled',
+            'Disabled sentinel',
+            GObject.ParamFlags.READABLE,
+            false
+        ),
+        placeholder: GObject.ParamSpec.boolean(
+            'placeholder',
+            'Placeholder',
+            'Placeholder sentinel',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            false
+        ),
+    },
+}, class Combo extends GObject.Object {
+    _init(params) {
+        super._init(params);
+    }
+
+    get keycode() {
+        if (this.disabled) {
+            return 0;
+        } else if (!this._keycode) {
+            const keymap = Gdk.Keymap.get_for_display(Gdk.Display.get_default());
+            const [ok, keys] = keymap.get_entries_for_keyval();
+            if (ok && keys.length) {
+                return keys[0].keycode;
+            } else {
+                return 0;
+            }
+        } else {
+            return this._keycode;
+        }
+    }
+
+    get keystr() {
+        if (this.disabled)
+            return '';
+        else
+            return Gtk.accelerator_name(this.keyval, this.mods);
+    }
+
+    get label() {
+        if (this.disabled)
+            return _('Disabled');
+        else
+            return Gtk.accelerator_get_label(this.keyval, this.mods);
+    }
+
+    get disabled() {
+        return !this.keyval && !this.mods;
+    }
+
+    toString() {
+        return `Combo(keycode=${this.keycode}, keyval=${this.keyval}, mods=${this.mods})`;
+    }
+});
+
+const Keybinding = GObject.registerClass({
+    GTypeName: 'Keybinding',
+    Implements: [Gio.ListModel],
+    Properties: {
+        section: GObject.ParamSpec.string(
+            'section',
+            'Section',
+            'Keybinding section title',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            null
+        ),
+        action: GObject.ParamSpec.string(
+            'action',
+            'Action',
+            'Keybinding action ID',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            null
+        ),
+        description: GObject.ParamSpec.string(
+            'description',
+            'Description',
+            'Keybinding action description',
+            GObject.ParamFlags.READABLE,
+            null
+        ),
+        label: GObject.ParamSpec.string(
+            'label',
+            'Label',
+            'Keybinding combo label',
+            GObject.ParamFlags.READABLE,
+            null
+        ),
+        combos: GObject.ParamSpec.object(
+            'combos',
+            'Combos',
+            'Key combos',
+            GObject.ParamFlags.READABLE,
+            Gio.ListModel.$gtype
+        ),
+        modified: GObject.ParamSpec.boolean(
+            'modified',
+            'Modified',
+            'True if the user has modified the shortcut from its default value',
+            GObject.ParamFlags.READABLE,
+            false
+        ),
+        enabled: GObject.ParamSpec.boolean(
+            'enabled',
+            'Enabled',
+            'True if this keybinding has any shortcuts',
+            GObject.ParamFlags.READABLE,
+            false
+        )
+    },
+    Signals: {
+        changed: {}
+    }
+}, class Keybinding extends GObject.Object {
+    _init(params = {}) {
+        super._init(params);
+
+        this._settings = Convenience.getSettings(KEYBINDINGS_KEY);
+
+        this._description = _(this._settings.settings_schema.get_key(this.action).get_summary());
+
+        this._combos = new Gio.ListStore();
+        this._combos.connect('items-changed', (_, position, removed, added) => {
+            this.items_changed(position, removed, added);
+            this.notify('label');
+        });
+
+        this._settings.connect(`changed::${this.action}`, () => this._load());
+
+        GLib.idle_add(0, () => this._load());
+    }
+
+    get description() {
+        return this._description;
+    }
+
+    get label() {
+        const labels = [...this.combos]
+              .filter(c => !isEmptyBinding(c))
+              .map(c => c.label);
+
+        let label = '';
+        if (labels.length == 0) {
+            label = _('Disabled');
+        } else {
+            label = labels.join(', ');
+        }
+
+        if (this.modified) {
+            label = `<b>${label}</b>`;
+        }
+
+        return label;
+    }
+
+    get combos() {
+        return this._combos;
+    }
+
+    get modified() {
+        return this._settings.get_user_value(this.action) != null;
+    }
+
+    get enabled() {
+        return [...this.combos].some((c) => !c.disabled);
+    }
+
+    vfunc_get_item_type() {
+        return Combo.$gtype;
+    }
+
+    vfunc_get_item(position) {
+        return this.combos.get_item(position);
+    }
+
+    vfunc_get_n_items() {
+        return this.combos.get_n_items();
+    }
+
+    add(combo) {
+        const [found, _] = this.find(combo);
+        if (found) return;
+        this.combos.append(combo);
+        if (!combo.disabled) {
+            this._store();
+        }
+    }
+
+    remove(combo) {
+        const [found, pos] = this.find(combo);
+        if (!found) return;
+        this.combos.remove(pos);
+        if (this.combos.get_n_items() == 0)
+            this.combos.append(new Combo());
+        this._store();
+    }
+
+    replace(oldCombo, newCombo) {
+        const [found, _] = this.find(newCombo);
+        if (found) return;
+        const [oldFound, pos] = this.find(oldCombo);
+        if (oldFound) {
+            this.combos.splice(pos, 1, [newCombo]);
+        } else {
+            this.combos.append(newCombo);
+        }
+        this._store();
+    }
+
+    disable() {
+        this._settings.set_strv(this.action, ['']);
+    }
+
+    reset() {
+        if (this._settings.get_user_value(this.action)) {
+            this._settings.reset(this.action);
+        }
+    }
+
+    find(combo) {
+        const pos = [...this.combos].findIndex(c => c.keystr === combo.keystr);
+        if (pos == -1) {
+            return [false];
+        } else {
+            return [true, pos];
+        }
+    }
+
+    _load() {
+        const keystrs = this._settings.get_strv(this.action) || [];
+        let combos = keystrs
+            .map(this._translateAboveTab)
+            .map(keystr => {
+                if (keystr != '')
+                    return Gtk.accelerator_parse(keystr);
+                else
+                    return [true, 0, 0];
+            })
+            .map(([, keyval, mods]) => new Combo({keyval: keyval, mods: mods}));
+
+        if (combos.length == 0) {
+            combos.push(new Combo());
+        }
+
+        this.combos.splice(0, this.combos.get_n_items(), combos);
+    }
+
+    _store() {
+        let filtered = [...this.combos]
+            .filter(c => !isEmptyBinding(c))
+            .map(c => c.keystr);
+        if (filtered.length == 0) {
+            filtered = [''];
+        }
+        this._settings.set_strv(this.action, filtered);
+    }
+
+    _translateAboveTab(keystr) {
+        if (!keystr.match(/Above_Tab/)) {
+            return keystr;
+        } else {
+            let keyvals = aboveTabKeyvals();
+            if (!keyvals)
+                return keystr.replace('Above_Tab', 'grave');
+
+            let keyname = Gdk.keyval_name(keyvals[0]);
+            return keystr.replace('Above_Tab', keyname);
+        }
+    }
+});
+
+var KeybindingsModel = GObject.registerClass({
+    GTypeName: 'KeybindingsModel',
+    Implements: [Gio.ListModel],
+    Signals: {
+        'collisions-changed': {
+            flags: GObject.SignalFlags.RUN_LAST | GObject.SignalFlags.DETAILED,
+        },
+    },
+}, class KeybindingsModel extends GObject.Object {
+    _init(params={}) {
+        super._init(params);
+
+        this._model = Gio.ListStore.new(Keybinding.$gtype);
+        this._model.connect('items-changed', (_, position, removed, added) => {
+            this.items_changed(position, removed, added);
+        });
+
+        this._combos = Gtk.FlattenListModel.new(this._model);
+        this._combos.connect('items-changed', () => {
+            // Room for optimization here.
+            this._updateCollisions();
+        });
+
+        this._actionToBinding = new Map();
+
+        this._settings = Convenience.getSettings(KEYBINDINGS_KEY);
+
+        GLib.idle_add(0, () => { this.load(); });
+    }
+
+    vfunc_get_item_type() {
+        return this._model.get_item_type();
+    }
+
+    vfunc_get_item(position) {
+        return this._model.get_item(position);
+    }
+
+    vfunc_get_n_items() {
+        return this._model.get_n_items();
+    }
+
+    get collisions() {
+        if (this._collisions === undefined) {
+            this._collisions = new Map();
+            this._updateCollisions();
+        }
+        return this._collisions;
+    }
+
+    getKeybinding(action) {
+        return this._actionToBinding.get(action);
+    }
+
+    find(binding) {
+        return this._model.find(binding);
+    }
+
+    load() {
+        let bindings = [];
+        for (const section in actions) {
+            for (const action of actions[section]) {
+                const binding = new Keybinding({
+                    section: section,
+                    action: action
+                });
+                bindings.push(binding);
+                this._actionToBinding.set(action, binding);
+            }
+        }
+        this._model.splice(0, this._model.get_n_items(), bindings);
+    }
+
+    _updateCollisions(position, removed, added) {
+        let map = new Map();
+        for (const binding of this._model) {
+            for (const combo of binding.combos) {
+                if (combo.disabled) continue;
+                map.set(combo.keystr, (map.get(combo.keystr) || new Set()).add(binding.action));
+            }
+        }
+        let changed = new Set();
+        for (const [keystr, actions] of map.entries()) {
+            if (actions.size > 1) {
+                if (!this.collisions.has(keystr)) {
+                    for (const action of actions) {
+                        changed.add(action);
+                    }
+                } else {
+                    let old = this.collisions.get(keystr);
+                    for (const action of symmetricDifference(old, actions)) {
+                        changed.add(action);
+                    }
+                }
+                this.collisions.set(keystr, actions);
+            } else {
+                for (const action of actions) {
+                    changed.add(action);
+                }
+                this.collisions.delete(keystr);
+            }
+        }
+        if (changed.size > 0) {
+            for (const action of changed) {
+                this.emit(`collisions-changed::${action}`);
+            }
+        }
+    }
+});
+
+const ComboRow = GObject.registerClass({
+    GTypeName: 'ComboRow',
+    Template: Extension.dir.get_child('KeybindingsComboRow.ui').get_uri(),
+    InternalChildren: [
+        'stack',
+        'shortcutPage',
+        'placeholderPage',
+        'editPage',
+        'shortcutLabel',
+        'deleteButton',
+        'conflictButton',
+        'conflictList',
+    ],
+    Properties: {
+        keybinding: GObject.ParamSpec.object(
+            'keybinding',
+            'Keybinding',
+            'Keybinding',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            Keybinding.$gtype
+        ),
+        combo: GObject.ParamSpec.object(
+            'combo',
+            'Combo',
+            'Key combo',
+            GObject.ParamFlags.READWRITE,
+            Combo.$gtype
+        ),
+        editing: GObject.ParamSpec.boolean(
+            'editing',
+            'Editing',
+            'Editing',
+            GObject.ParamFlags.READWRITE,
+            false
+        ),
+    },
+    Signals: {
+        'collision-activated': {
+            param_types: [Keybinding.$gtype],
+        },
+    },
+}, class ComboRow extends Gtk.ListBoxRow {
+    _init(params = {}) {
+        super._init(params);
+
+        let controller;
+        controller = Gtk.EventControllerKey.new();
+        controller.connect('key-pressed', (controller, keyval, keycode, state) => {
+            this._onKeyPressed(controller, keyval, keycode, state);
+        });
+        this.add_controller(controller);
+
+        controller = Gtk.EventControllerFocus.new();
+        controller.connect('leave', () => {
+            this.editing = false;
+        });
+        this.add_controller(controller);
+
+        this._collisions = Gio.ListStore.new(Keybinding.$gtype);
+
+        this._conflictList.bind_model(this._collisions, binding => this._createConflictRow(binding));
+
+        GLib.idle_add(0, () => this._updateState());
+    }
+
+    get combo() {
+        if (this._combo === undefined)
+            this._combo = null;
+        return this._combo;
+    }
+
+    set combo(value) {
+        if (value && this._combo && this._combo.keystr == value.keystr)
+            return;
+        this._combo = value;
+        this.notify('combo');
+        this._updateState();
+    }
+
+    get editing() {
+        if (this._editing === undefined)
+            this._editing = false;
+        return this._editing;
+    }
+
+    set editing(value) {
+        if (this.editing === value)
+            return;
+        this._editing = value;
+        this.notify('editing');
+        this._updateState();
+    }
+
+    get collisions() {
+        return [...this._collisions];
+    }
+
+    set collisions(value) {
+        this._collisions.splice(0, this._collisions.get_n_items(), value);
+    }
+
+    _createConflictRow(binding) {
+        return new Gtk.Label({
+            label: binding.description,
+        });
+    }
+
+    _onConflictRowActivated(list, row) {
+        const binding = this._collisions.get_item(row.get_index());
+        this.emit('collision-activated', binding);
+    }
+
+    _grabKeyboard() {
+        this.get_root().get_surface().inhibit_system_shortcuts(null);
+    }
+
+    _ungrabKeyboard() {
+        this.get_root().get_surface().restore_system_shortcuts();
+    }
+
+    _onDeleteButtonClicked() {
+        GLib.idle_add(0, () => this.keybinding.remove(this.combo));
+    }
+
+    _onKeyPressed(controller, keyval, keycode, state) {
+        // Adapted from Control Center, cc-keyboard-shortcut-editor.c
+
+        if (!this.editing) return Gdk.EVENT_PROPAGATE;
+
+        let modmask = state & Gtk.accelerator_get_default_mod_mask();
+        let keyvalLower = Gdk.keyval_to_lower(keyval);
+
+        // Normalize <Tab>
+        if (keyvalLower == Gdk.KEY_ISO_Left_Tab) {
+            keyvalLower = Gdk.KEY_Tab;
+        }
+
+        // Put Shift back if it changed the case of the key
+        if (keyvalLower != keyval) {
+            modmask |= Gdk.ModifierType.SHIFT_MASK;
+        }
+
+        if (keyvalLower == Gdk.KEY_Sys_Req && (modmask & Gdk.ModifierType.ALT_MASK) != 0) {
+            // Don't allow SysRq as a keybinding, but allow Alt+Print
+            keyvalLower = Gdk.KEY_Print;
+        }
+
+        const event = controller.get_current_event();
+        const isModifier = event.is_modifier();
+
+        // Escape cancels
+        if (!isModifier && modmask == 0 && keyvalLower == Gdk.KEY_Escape) {
+            this.editing = false;
+            if (this.combo.placeholder) {
+                this.keybinding.remove(this.combo);
+            }
+            return Gdk.EVENT_STOP;
+        }
+
+        // Backspace deletes
+        if (!isModifier && modmask == 0 && keyvalLower == Gdk.KEY_BackSpace) {
+            this._updateKeybinding(new Combo());
+            return Gdk.EVENT_STOP;
+        }
+
+        // Remove CapsLock
+        modmask &= ~Gdk.ModifierType.LOCK_MASK;
+
+        this._updateKeybinding(new Combo({keycode: keycode, keyval: keyvalLower, mods: modmask}));
+
+        return Gdk.EVENT_STOP;
+    }
+
+    _updateKeybinding(newCombo) {
+        let isValid = isValidBinding(newCombo);
+        let isEmpty = isEmptyBinding(newCombo);
+
+        const oldCombo = this.combo;
+        if (isEmptyBinding(oldCombo) && isValid) {
+            this.editing = false;
+            this.keybinding.add(newCombo);
+            return;
+        }
+
+        if (isEmpty) {
+            this.editing = false;
+            this.keybinding.remove(oldCombo);
+            return;
+        }
+
+        if (isValid) {
+            this.editing = false;
+            this.keybinding.replace(oldCombo, newCombo);
+        }
+    }
+
+    _updateState() {
+        if (this.editing) {
+            this.add_css_class('editing');
+            this._stack.visible_child = this._editPage;
+            this.grab_focus();
+            this._grabKeyboard();
+        } else {
+            this.remove_css_class('editing');
+            this._stack.visible_child = this._shortcutPage;
+            this._ungrabKeyboard();
+
+            if (this._combo && !this._combo.disabled) {
+                this._shortcutLabel.accelerator = this._combo.keystr;
+                this._deleteButton.visible = true;
+                this._conflictButton.visible = this.collisions.length > 0;
+            } else {
+                this._shortcutLabel.accelerator = '';
+                this._deleteButton.visible = false;
+            }
+        }
+    }
+});
+
+const KeybindingsRow = GObject.registerClass({
+    GTypeName: 'KeybindingsRow',
+    Template: Extension.dir.get_child('KeybindingsRow.ui').get_uri(),
+    InternalChildren: [
+        'header',
+        'descLabel',
+        'accelLabel',
+        'conflictIcon',
+        'revealer',
+        'comboList',
+    ],
+    Properties: {
+        keybindings: GObject.ParamSpec.object(
+            'keybindings',
+            'Keybindings',
+            'Keybindings model',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            KeybindingsModel.$gtype
+        ),
+        keybinding: GObject.ParamSpec.object(
+            'keybinding',
+            'Keybinding',
+            'Keybinding',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            Keybinding.$gtype
+        ),
+        expanded: GObject.ParamSpec.boolean(
+            'expanded',
+            'Expanded',
+            'Expanded',
+            GObject.ParamFlags.READWRITE,
+            false
+        ),
+        collisions: GObject.ParamSpec.jsobject(
+            'collisions',
+            'Collisions',
+            'Colliding keybindings',
+            GObject.ParamFlags.READABLE,
+        ),
+    },
+    Signals: {
+        'collision-activated': {
+            param_types: [Keybinding.$gtype],
+        },
+    },
+}, class KeybindingsRow extends Gtk.ListBoxRow {
+    _init(params = {}) {
+        super._init(params);
+
+        this._actionGroup = new Gio.SimpleActionGroup();
+        this.insert_action_group('keybinding', this._actionGroup);
+
+        let action;
+        action = new Gio.SimpleAction({
+            name: 'reset',
+            enabled: this.keybinding.modified
+        });
+        action.connect('activate', () => this.keybinding.reset());
+        this._actionGroup.add_action(action);
+
+        action = new Gio.SimpleAction({name: 'add'});
+        action.connect('activate', () => this.keybinding.add(new Combo({placeholder: true})));
+        this._actionGroup.add_action(action);
+
+        const gesture = Gtk.GestureClick.new();
+        gesture.set_button(Gdk.BUTTON_PRIMARY);
+        gesture.connect('released', (controller) => {
+            this.expanded = !this.expanded;
+            controller.set_state(Gtk.EventSequenceState.CLAIMED);
+        });
+        this._header.add_controller(gesture);
+
+        this._descLabel.label = this.keybinding.description;
+        this._descLabel.tooltip_text = this.keybinding.description;
+
+        this.keybinding.connect('notify::label', () => this._updateState());
+
+        this._comboList.bind_model(this.keybinding, (combo) => this._createRow(combo));
+
+        this.keybindings.connect(
+            `collisions-changed::${this.keybinding.action}`,
+            () => { this._onCollisionsChanged(); }
+        );
+
+        this._updateState();
+    }
+
+    get expanded() {
+        if (this._expanded === undefined)
+            this._expanded = false;
+        return this._expanded;
+    }
+
+    set expanded(value) {
+        if (this._expanded === value)
+            return;
+
+        this._expanded = value;
+        this.notify('expanded');
+        this._updateState();
+    }
+
+    get collisions() {
+        if (this._collisions == undefined) {
+            this._collisions = new Map();
+        }
+        return this._collisions;
+    }
+
+    _createRow(combo) {
+        const row = new ComboRow({
+            keybinding: this.keybinding,
+            combo: combo,
+        });
+        if (combo.placeholder) {
+            GLib.idle_add(0, () => { row.editing = true; });
+        }
+        this.connect('notify::collisions', () => {
+            row.collisions = this.collisions.get(combo.keystr) || [];
+        });
+        row.connect('collision-activated', (_, binding) => {
+            this.emit('collision-activated', binding);
+        });
+        return row;
+    }
+
+    _onCollisionsChanged() {
+        const map = new Map();
+        const collisions = this.keybindings.collisions;
+        for (const combo of this.keybinding.combos) {
+            const actions = collisions.get(combo.keystr);
+            if (!actions) continue;
+            map.set(
+                combo.keystr,
+                [...actions]
+                    .filter(a => a !== this.keybinding.action)
+                    .map(a => this.keybindings.getKeybinding(a))
+            );
+        }
+        this._collisions = map;
+        this.notify('collisions');
+        this._updateState();
+    }
+
+    _onRowActivated(list, row) {
+        if (row.is_focus()) {
+            row.editing = !row.editing;
+        }
+    }
+
+    _updateState() {
+        GLib.idle_add(0, () => {
+            this._accelLabel.label = this.keybinding.label;
+            if (this.expanded) {
+                this._accelLabel.hide();
+                this._conflictIcon.visible = false;
+                this._revealer.reveal_child = true;
+                this.add_css_class('expanded');
+            } else {
+                this._accelLabel.show();
+                this._conflictIcon.visible = this.collisions.size > 0;
+                this._revealer.reveal_child = false;
+                this.remove_css_class('expanded');
+            }
+        });
+    }
+});
+
+var KeybindingsPane = GObject.registerClass({
+    GTypeName: 'KeybindingsPane',
+    Template: Extension.dir.get_child('KeybindingsPane.ui').get_uri(),
+    InternalChildren: [
+        'search',
+        'listbox',
+    ],
+}, class KeybindingsPane extends Gtk.Box {
+    _init(params = {}) {
+        super._init(params);
+
+        this._bindings = new KeybindingsModel();
+
+        this._filter = new Gtk.StringFilter({
+            expression: Gtk.PropertyExpression.new(Keybinding.$gtype, null, 'description'),
+            ignore_case: true,
+            match_mode: Gtk.StringFilterMatchMode.SUBSTRING
+        });
+
+        const filteredBindings = new Gtk.FilterListModel({
+            model: this._bindings,
+            filter: this._filter
+        });
+
+        this._listbox.bind_model(filteredBindings, (keybinding) => this._createRow(keybinding));
+        this._listbox.set_header_func((row, before, data) => this._onSetHeader(row, before, data));
+
+        this._expandedRow = null;
+    }
+
+    _createHeader(row, before) {
+        const box = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL});
+        if (before)
+            box.append(new Gtk.Separator({orientation: Gtk.Orientation.HORIZONTAL}));
+        box.append(new Gtk.Label({
+            use_markup: true,
+            label: _(`<b>${sections[row.keybinding.section]}</b>`),
+            xalign: 0.0,
+            margin_top: 24,
+            margin_bottom: 6,
+            margin_start: 12,
+            margin_end: 12
+        }));
+        box.append(new Gtk.Separator({orientation: Gtk.Orientation.HORIZONTAL}));
+        return box;
+    }
+
+    _createRow(keybinding) {
+        const row = new KeybindingsRow({keybindings: this._bindings, keybinding: keybinding});
+        row.connect('notify::expanded', (row) => this._onRowExpanded(row));
+        row.connect('collision-activated', (_, binding) => this._onCollisionActivated(binding));
+        return row;
+    }
+
+    _onCollisionActivated(keybinding) {
+        const [found, pos] = this._bindings.find(keybinding);
+        if (found) {
+            const row = this._listbox.get_row_at_index(pos);
+            row.activate();
+        }
+    }
+
+    _onSearchChanged() {
+        this._filter.search = this._search.text || null;
+    }
+
+    _onRowActivated(list, row) {
+        if (!row.is_focus()) return;
+        row.expanded = !row.expanded;
+    }
+
+    _onRowExpanded(row) {
+        if (row.expanded) {
+            if (this._expandedRow) this._expandedRow.expanded = false;
+            this._expandedRow = row;
+        } else if (this._expandedRow === row) {
+            this._expandedRow = null;
+        }
+    }
+
+    _onSetHeader(row, before, data) {
+        const header = row.get_header();
+        if (!before || before.keybinding.section != row.keybinding.section) {
+            if (!header || header instanceof Gtk.Separator) {
+                row.set_header(this._createHeader(row, before));
+            }
+        } else if (!header || !(header instanceof Gtk.Separator)) {
+            row.set_header(new Gtk.Separator({orientation: Gtk.Orientation.HORIZONTAL}));
+        }
+    }
+});
+
+let _aboveTabKeyvals = null;
+
+function aboveTabKeyvals() {
+    if (!_aboveTabKeyvals) {
+        const keycode = 0x29 + 8; // KEY_GRAVE
+        let display = Gdk.Display.get_default();
+        let [, , keyvals] = display.map_keycode(keycode);
+        _aboveTabKeyvals = keyvals;
+    }
+    return _aboveTabKeyvals;
+}
+
+function symmetricDifference(setA, setB) {
+    let _difference = new Set(setA);
+    for (let elem of setB) {
+        if (_difference.has(elem)) {
+            _difference.delete(elem);
+        } else {
+            _difference.add(elem);
+        }
+    }
+    return _difference;
+}

--- a/resources/prefs.css
+++ b/resources/prefs.css
@@ -1,0 +1,43 @@
+list.keybindings > row {
+    padding: 0 0;
+    background-color: transparent;
+}
+
+list.keybindings > row:hover {
+    background-color: transparent;
+}
+
+list.keybindings > row.expanded {
+    background-color: alpha(darker(@theme_base_color), 0.33);
+}
+
+list.keybindings > row.expanded:backdrop:not(:hover):not(:active):not(:selected) {
+    background-color: alpha(darker(@theme_unfocused_base_color), 0.33);
+}
+
+list.keybindings > row .header,
+list.combos > row {
+    padding: 8px 12px;
+    min-height: 32px;
+}
+
+list.keybindings > row .header:hover {
+    background-color: alpha(@theme_fg_color, 0.10);
+}
+
+list.keybindings > row .header:hover:backdrop {
+    background-color: alpha(@theme_unfocused_fg_color, 0.10);
+}
+
+list.keybindings > row.expanded label.description {
+    font-weight: bold;
+}
+
+list.combos {
+    background-color: transparent;
+}
+
+list.combos > .editing {
+    background-color: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
+}

--- a/settings.js
+++ b/settings.js
@@ -235,6 +235,17 @@ function keycomboToKeystr(combo) {
     return keystr;
 }
 
+function keycomboToKeylab(combo) {
+    let [mutterKey, mods] = combo.split('|').map(s => Number.parseInt(s));
+    let key = mutterKey;
+    if (mutterKey === META_KEY_ABOVE_TAB)
+        key = 97; // a
+    let keylab = Gtk.accelerator_get_label(key, mods);
+    if (mutterKey === META_KEY_ABOVE_TAB)
+        keylab = keylab.replace(/a$/, 'Above_Tab');
+    return keylab;
+}
+
 function generateKeycomboMap(settings) {
     let map = {};
     for (let name of settings.list_keys()) {


### PR DESCRIPTION
Rewrite preferences in GTK4. This may clobber some recent work done on other forks.

TODO:
- [x] Retain scroll position when adding/removing shortcuts
  - Fixed by replacing `TreeListModel` with nested `ListBox` widgets
- [x] Show shortcut conflicts (they are detected but not wired in to KeybindingsRow)
  - See screenshot below

Screenshots:

![image](https://user-images.githubusercontent.com/129148/147287450-8a9eeb69-989b-490e-b881-36367b79cc00.png)

![image](https://user-images.githubusercontent.com/129148/147287485-8c099fd6-0331-4580-9132-ec49e7b2e7e3.png)

![paperwm-1](https://user-images.githubusercontent.com/129148/147424962-9e024be9-a268-4293-8d23-3a668371b3b4.png)

![image](https://user-images.githubusercontent.com/129148/147425061-69d2fbfb-d8eb-498a-a570-f0b536ae7d45.png)

![paperwm-2](https://user-images.githubusercontent.com/129148/147425245-a4cf8954-2923-45d3-a0e8-097ef2bfab0f.png)

