### PR TITLE
tiling: Remove topBarAdjustment from workArea

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -190,7 +190,7 @@ var MoveGrab = class MoveGrab {
         const rowZoneMargin = 250 + halfGap;
 
         let target = null;
-        const tilingHeight = space.height - Tiling.panelBox.height;
+        const tilingHeight = space.height - Main.layoutManager.panelBox.height;
 
         let fakeClone = {
             targetX: null,
@@ -237,7 +237,7 @@ var MoveGrab = class MoveGrab {
                     marginB: columnZoneMarginViz,
                     space: space,
                     actorParams: {
-                        y: Tiling.panelBox.height,
+                        y: Main.layoutManager.panelBox.height,
                         height: tilingHeight
                     }
                 };

--- a/tiling.js
+++ b/tiling.js
@@ -46,8 +46,6 @@ var stack_margin = 75;
 // Some features use this to determine if to sizes is considered equal. ie. `abs(w1 - w2) < sizeSlack`
 var sizeSlack = 30;
 
-var panelBox = Main.layoutManager.panelBox;
-
 var PreviewMode = {NONE: 0, STACK: 1, SEQUENTIAL: 2};
 var inPreview = PreviewMode.NONE;
 
@@ -260,11 +258,8 @@ class Space extends Array {
         let workArea = Main.layoutManager.getWorkAreaForMonitor(this.monitor.index);
         workArea.x -= this.monitor.x;
         workArea.y -= this.monitor.y;
-        let topBarAdjustment = this.showTopBar && (prefs.topbar_follow_focus || this.monitor === Main.layoutManager.primaryMonitor) ?
-            panelBox.height : 0;
-        workArea.height = (workArea.y + workArea.height -
-                               topBarAdjustment - prefs.vertical_margin - prefs.vertical_margin_bottom);
-        workArea.y = topBarAdjustment + prefs.vertical_margin;
+        workArea.height -= prefs.vertical_margin + prefs.vertical_margin_bottom;
+        workArea.y += prefs.vertical_margin;
         return workArea;
     }
 


### PR DESCRIPTION
This removes the hardcoded top margin, which I don't believe is necessary because `getWorkAreaForMonitor` already accounts for the panel area.

This improves compatibility with bottom-pinned panels such as when using the Dash to Panel extension.