### PR TITLE
Replace 3-finger workspace swipe to 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .config
 TAGS
+libgnome-shell-replaced.so

--- a/install.sh
+++ b/install.sh
@@ -82,3 +82,29 @@ else
     
     echo Success
 fi
+
+echo
+read -p "Replace 3-finger swipe workspace switch gesture with 4-finger swipe?
+Warning: this will forcefully restart your current GNOME session.
+Please save your work before proceeding. [Y/n]? " consent
+
+case "$consent" in
+    (Y|y|"")
+        rm -f libgnome-shell-replaced.so
+        python swipe3to4.py
+
+        if [[ -f libgnome-shell-replaced.so ]]
+        then
+            echo "Replacing gesture, root required"
+
+            chmod a+x libgnome-shell-replaced.so
+            sudo chown root:root libgnome-shell-replaced.so
+            sudo cp libgnome-shell-replaced.so /usr/lib64/gnome-shell/libgnome-shell.so
+        else
+            echo "Swipe gesture already replaced, nothing to do"
+        fi
+    ;;
+    *)
+        exit
+    ;;
+esac

--- a/swipe3to4.py
+++ b/swipe3to4.py
@@ -1,0 +1,15 @@
+#original author: icedman
+#taken/reworked from https://github.com/icedman/gnome-shell-hammer
+
+f=open("/usr/lib64/gnome-shell/libgnome-shell.so","rb")
+s=f.read()
+f.close()
+
+str=b'GESTURE_FINGER_COUNT\x20=\x203'
+
+if (s.find(str) != -1):
+    s=s.replace(str,b'GESTURE_FINGER_COUNT\x20=\x204')
+
+    f=open("libgnome-shell-replaced.so","wb")
+    f.write(s)
+    f.close()


### PR DESCRIPTION
This is based on [gnome-shell-hammer](https://github.com/icedman/gnome-shell-hammer) extension. I am not the author. I just picked gesture replacement from one of the scripts in that repo.

PaperWM uses 3-finger swipes to move between windows while GNOME uses the same gesture to switch between workspaces. Due to this, PaperWM is not really usable on laptops with touchpads.

This script works by replacing binary data in `/usr/lib64/gnome-shell/libgnome-shell.so` (it searches `GESTURE_FINGER_COUNT` constant) so it might get broken in future releases of GNOME. Unfortunately, GNOME devs seem intent on not making this configurable which is why this approach was probably used in the first place. After this is applied, PaperWM isn't fighting anymore with built-in gesture from GNOME.

I would prefer this to be done in a different way if possible, but again, I don't see any currently. This script is added to `install.sh`.