### PR TITLE
Fix scratch layer matching

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -302,16 +302,17 @@ function findConflicts(schemas) {
 */
 var winprops = [];
 
-function _winprop_match_p_helper(user_attr_prop, win_prop) {
+function _winprop_match_p_helper(user_attr_prop, _win_prop) {
     // matches user-supplied conditions with null checking
     if (user_attr_prop) {
+        let win_prop = String(_win_prop);
         if (user_attr_prop.constructor === RegExp) {
             // treat prop condition as regex
             if (!win_prop.match(user_attr_prop))
                 return false;
         } else {
             // treat prop condition as string
-            if (user_attr_prop !== String(win_prop))
+            if (user_attr_prop !== win_prop)
                 return false;
         }
     }

--- a/settings.js
+++ b/settings.js
@@ -302,24 +302,30 @@ function findConflicts(schemas) {
 */
 var winprops = [];
 
-function winprop_match_p(meta_window, prop) {
-    let wm_class = meta_window.wm_class || "";
-    let title = meta_window.title;
-    if (prop.wm_class.constructor === RegExp) {
-        if (!wm_class.match(prop.wm_class))
-            return false;
-    } else if (prop.wm_class !== wm_class) {
-        return false;
-    }
-    if (prop.title) {
-        if (prop.title.constructor === RegExp) {
-            if (!title.match(prop.title))
+function _winprop_match_p_helper(user_attr_prop, win_prop) {
+    // matches user-supplied conditions with null checking
+    if (user_attr_prop) {
+        if (user_attr_prop.constructor === RegExp) {
+            // treat prop condition as regex
+            if (!win_prop.match(user_attr_prop))
                 return false;
         } else {
-            if (prop.title !== title)
+            // treat prop condition as string
+            if (user_attr_prop !== win_prop)
                 return false;
         }
     }
+
+    return true;
+}
+
+function winprop_match_p(meta_window, prop) {
+    // check wm_class
+    if (!_winprop_match_helper(prop.wm_class, meta_window.wm_class))
+        return false;
+    // check wm_title
+    if (!_winprop_match_helper(prop.title, meta_window.title))
+        return false;
 
     return true;
 }

--- a/settings.js
+++ b/settings.js
@@ -311,7 +311,7 @@ function _winprop_match_p_helper(user_attr_prop, win_prop) {
                 return false;
         } else {
             // treat prop condition as string
-            if (user_attr_prop !== win_prop)
+            if (user_attr_prop !== String(win_prop))
                 return false;
         }
     }
@@ -321,10 +321,10 @@ function _winprop_match_p_helper(user_attr_prop, win_prop) {
 
 function winprop_match_p(meta_window, prop) {
     // check wm_class
-    if (!_winprop_match_helper(prop.wm_class, meta_window.wm_class))
+    if (!_winprop_match_p_helper(prop.wm_class, meta_window.wm_class))
         return false;
     // check wm_title
-    if (!_winprop_match_helper(prop.title, meta_window.title))
+    if (!_winprop_match_p_helper(prop.title, meta_window.title))
         return false;
 
     return true;


### PR DESCRIPTION
Error checking when deciding on scratch layer matching (previously there was null exception when `wm_class` was not defined in the user setting. (e.g. when user only want to match by `wm_title`)

I've also commented out the hard-coded gnome-screenshot to scratch, because it keeps on crashing my desktop (see https://github.com/paperwm/PaperWM/issues/376#issuecomment-962700960)

