### PR TITLE
Allow overriding stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ When the tiling is active <kbd>Super</kbd><kbd>Shift</kbd><kbd>Tab</kbd> selects
 
 A default user configuration, `user.js`, is created in `~/.config/paperwm/` with three functions `init`, `enable` and `disable`. `init` will run only once on startup, `enable` and `disable` will be run whenever extensions are being told to disable and enable themselves. Eg. when locking the screen with <kbd>Super</kbd><kbd>L</kbd>.
 
-You can also supply a custom `stylesheet.css` in `~/.config/paperwm/`, and paperwm will override its own default stylesheet located at `/org/gnome/shell/extensions/paperwm/stylesheet.css`
+You can also supply a custom `stylesheet.css` in `~/.config/paperwm/`, and paperwm will override its own default stylesheet located at the extension installation location, e.g., `~/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/stylesheet.css  or `/usr/share/gnome-shell/extensions/paperwm@hedning:matrix.org/stylesheet.css`.
 
 We also made an emacs package, [gnome-shell-mode](https://github.com/paperwm/gnome-shell-mode), to make hacking on the config and writing extensions a more pleasant experience. To support this out of the box we also install a `metadata.json` so gnome-shell-mode will pick up the correct file context, giving you completion and interactive evaluation ala. looking glass straight in emacs.
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ When the tiling is active <kbd>Super</kbd><kbd>Shift</kbd><kbd>Tab</kbd> selects
 
 A default user configuration, `user.js`, is created in `~/.config/paperwm/` with three functions `init`, `enable` and `disable`. `init` will run only once on startup, `enable` and `disable` will be run whenever extensions are being told to disable and enable themselves. Eg. when locking the screen with <kbd>Super</kbd><kbd>L</kbd>.
 
+You can also supply a custom `stylesheet.css` in `~/.config/paperwm/`, and paperwm will override its own default stylesheet located at `/org/gnome/shell/extensions/paperwm/stylesheet.css`
+
 We also made an emacs package, [gnome-shell-mode](https://github.com/paperwm/gnome-shell-mode), to make hacking on the config and writing extensions a more pleasant experience. To support this out of the box we also install a `metadata.json` so gnome-shell-mode will pick up the correct file context, giving you completion and interactive evaluation ala. looking glass straight in emacs.
 
 Pressing <kbd>Super</kbd><kbd>Insert</kbd> will assign the active window to a global variable `metaWindow`, its [window actor](https://developer.gnome.org/meta/stable/MetaWindowActor.html) to `actor`, its [workspace](https://developer.gnome.org/meta/stable/MetaWorkspace.html) to `workspace` and its PaperWM style workspace to `space`. This makes it easy to inspect state and test things out.

--- a/extension.js
+++ b/extension.js
@@ -1,3 +1,5 @@
+const { St } = imports.gi;
+
 // polyfill workspace_manager that was introduced in 3.30 (must happen before modules are imported)
 if (!global.workspace_manager) {
     global.workspace_manager = global.screen;
@@ -179,6 +181,12 @@ function initUserConfig() {
 
     if (hasUserConfigFile()) {
         Extension.imports.searchPath.push(getConfigDir().get_path());
+    }
+
+    let userStylesheet = getConfigDir().get_child("stylesheet.css");
+    if (userStylesheet.query_exists(null)) {
+        let themeContext = St.ThemeContext.get_for_stage(global.stage);
+        themeContext.get_theme().load_stylesheet(userStylesheet);
     }
 }
 


### PR DESCRIPTION
For example, I have removed the cyan tint in the background of the window by having the following contents in my `~/.config/paperwm/stylesheet.css`
```css
.paper-mm-selected-window {
    border: 10px;
    border-radius: 5px;
}

.paperwm-selection {
    border: 2px;
    border-radius: 8px;
    background-color: rgba(0, 0, 0, 0.1);  // this remove background colour
}
```