### PR TITLE
fix: don't barf with a null metaWindow

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -3271,6 +3271,9 @@ function slurp(metaWindow) {
 }
 
 function barf(metaWindow) {
+    if (!metaWindow)
+        return;
+
     let space = spaces.spaceOfWindow(metaWindow);
     let index = space.indexOf(metaWindow);
     if (index === -1)


### PR DESCRIPTION
Using next-release branch of PaperWM-community on Gnome 40, I have noticed that some of the keybindings do not work for some reason. E.g. "Super+V", whic should open the calendar/notifications widget. Every hit of this keybinding additionally leads to a JS stack trace in the gnome journal.

This fix doesn't bring back the functionality, i.e. keybindigs are still not working (I know about Super+V and Super+S), but it removes the annoying stack trace.

Stack trace:
```
Dec 26 13:32:00 YogaTux gnome-shell[32061]: JS ERROR: TypeError: meta_window is null
                                            spaceOfWindow@/home/rasmi/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:2136:9
                                            barf@/home/rasmi/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:3274:24
                                            dynamic_function_ref/<@/home/rasmi/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/utils.js:104:33
                                            asKeyHandler/<@/home/rasmi/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/keybindings.js:268:20
```