### PR TITLE
Fix "actor deprecated" warnings

### DIFF
--- a/kludges.js
+++ b/kludges.js
@@ -506,7 +506,7 @@ function enable() {
         MessageTray.prototype._updateState
             = function () {
                 let hasMonitor = Main.layoutManager.primaryMonitor != null;
-                this.actor.visible = !this._bannerBlocked && hasMonitor && this._banner != null;
+                this.visible = !this._bannerBlocked && hasMonitor && this._banner != null;
                 if (this._bannerBlocked || !hasMonitor)
                     return;
 

--- a/topbar.js
+++ b/topbar.js
@@ -505,13 +505,13 @@ function enable () {
 
     menu = new WorkspaceMenu();
     // Work around 'actor' warnings
-    let panelActor = Main.panel.actor;
+    let panel = Main.panel;
     function fixLabel(label) {
         let point = new Clutter.Vertex({x: 0, y: 0});
-        let r = label.apply_relative_transform_to_point(panelActor, point);
+        let r = label.apply_relative_transform_to_point(panel, point);
 
         for (let [workspace, space] of Tiling.spaces) {
-            space.label.set_position(panelActor.x + Math.round(r.x), panelActor.y + Math.round(r.y));
+            space.label.set_position(panel.x + Math.round(r.x), panel.y + Math.round(r.y));
             let fontDescription = label.clutter_text.font_description;
             space.label.clutter_text.set_font_description(fontDescription);
         }
@@ -520,7 +520,7 @@ function enable () {
     menu.actor.show();
 
     // Force transparency
-    panelActor.set_style('background-color: rgba(0, 0, 0, 0.35);');
+    panel.set_style('background-color: rgba(0, 0, 0, 0.35);');
     [Main.panel._rightCorner, Main.panel._leftCorner]
         .forEach(c => c.actor.opacity = 0);
 


### PR DESCRIPTION
There are a lot of "actor deprecated" warnnings everywhere and I believe previous fixes (902e8ed86ef826c5d118dcb975cf391e8864b0d8) of this warnings could be done differently.

Also I have a suspicion that this fix improves instability of working on Gnome40: before applying the fix, paperwm would crash pretty randomly. However it may just a coincidence and effect of other patches. I haven't tested this patch in the isolation to check that.