### PR TITLE
Disabling workspace animation to prevent glitchy behaviour on multi-screen setups

### DIFF
--- a/animations.js
+++ b/animations.js
@@ -1,0 +1,30 @@
+const WorkspaceAnimation = imports.ui.workspaceAnimation;
+let originalAnimateSwitch = null;
+
+/**
+ * Disables the workspace animations and by this weird gittering when
+ * switching between panes and when the focus on a monitor switch happens
+ */
+function enable() {
+    try {
+        originalAnimateSwitch = WorkspaceAnimation.WorkspaceAnimationController.prototype.animateSwitch;
+
+        WorkspaceAnimation.WorkspaceAnimationController.prototype.animateSwitch = function (
+            _,
+            _,
+            _,
+            complete
+        ) {
+            complete();
+        };
+    } catch (_) { }
+}
+
+/**
+ * Re-enables the workspace animations
+ */
+function disable() {
+    if (originalAnimateSwitch) {
+        WorkspaceAnimation.WorkspaceAnimationController.prototype.animateSwitch = originalAnimateSwitch;
+    }
+}

--- a/extension.js
+++ b/extension.js
@@ -32,7 +32,7 @@ if (!global.workspace_manager) {
  */
 var modules = [
     'tiling', 'navigator', 'keybindings', 'scratch', 'liveAltTab', 'utils',
-    'stackoverlay', 'app', 'kludges', 'topbar', 'settings','gestures'
+    'stackoverlay', 'app', 'kludges', 'topbar', 'settings','gestures', 'animations'
 ];
 
 /**


### PR DESCRIPTION
When using multiple screens are attached and you move your cursor to a different screen, the focus comes with it so a workspace-change animation is triggered. This PR disables this.