### PR TITLE
keymap: Fix shotcuts with grave key shown as disabled

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -645,13 +645,9 @@ function createKeybindingWidget(settings, searchEntry) {
 
 function parseAccelerator(accelerator) {
     let key, mods;
-    // if (accelerator.match(/Above_Tab/)) {
-    //     let keymap = Gdk.Keymap.get_default();
-    //     let entries = keymap.get_entries_for_keycode(49)[1];
-    //     let keyval = keymap.lookup_key(entries[0]);
-    //     let name = Gtk.accelerator_name(keyval, 0);
-    //     accelerator = accelerator.replace('Above_Tab', name);
-    // }
+    if (accelerator.match(/Above_Tab/)) {
+        accelerator = accelerator.replace('Above_Tab', 'grave');
+    }
 
     [success, key, mods] = Gtk.accelerator_parse(accelerator);
     return [key, mods];


### PR DESCRIPTION
Having shortcuts using the grave key shown as disabled is not hindering them from working, but it looks and might lets the user question, which action pressing a certain key combo actually triggers.