### PR TITLE
fix use of deprecated source.notify()

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -194,7 +194,7 @@ function notify(msg, details, params) {
     Main.messageTray.add(source);
     let notification = new MessageTray.Notification(source, msg, details, params);
     notification.setResident(true); // Usually more annoying that the notification disappear than not
-    source.notify(notification);
+    source.showNotification(notification);
     return notification;
 }
 


### PR DESCRIPTION
I was seeing this error when trying to enable:
```
JS ERROR: Extension paperwm@hedning:matrix.org: Error: Expected type string for argument 'property_name' but got type GObject_Object
notify@/home/cooperc/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/extension.js:197:12
errorNotification@/home/cooperc/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/extension.js:211:32
safeCall@/home/cooperc/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/extension.js:64:26
run@/home/cooperc/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/extension.js:49:17
init@/home/cooperc/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/extension.js:98:12
_callExtensionInit@resource:///org/gnome/shell/ui/extensionSystem.js:428:50
loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:345:27
_loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:594:18
collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:28
_loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:573:19
_enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:603:18
_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:634:18
init@resource:///org/gnome/shell/ui/extensionSystem.js:56:14
_initializeUI@resource:///org/gnome/shell/ui/main.js:265:22
start@resource:///org/gnome/shell/ui/main.js:162:5
@resource:///org/gnome/shell/ui/init.js:6:17
```
This resolved the issue. This call was deprecated a while ago and finally removed. See https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/16c7739170ffb0dd59f75f16d65bc8a97bd2033e.

Honestly, I'm not really sure how none of you have run into this... maybe just have it already enabled, so no problem.