### PR TITLE
Fix defined keybinds not applying correctly

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -194,7 +194,7 @@ function notify(msg, details, params) {
     Main.messageTray.add(source);
     let notification = new MessageTray.Notification(source, msg, details, params);
     notification.setResident(true); // Usually more annoying that the notification disappear than not
-    source.notify(notification);
+    source.showNotification(notification);
     return notification;
 }
 

--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,6 @@
   "description": "Tiling window manager with a twist",
   "url": "https://github.com/paperwm/PaperWM",
   "settings-schema": "org.gnome.Shell.Extensions.PaperWM",
-  "shell-version": [ "40", "41" ],
-  "version": "41.0"
+  "shell-version": [ "40", "41", "42" ],
+  "version": "42.0"
 }

--- a/minimap.js
+++ b/minimap.js
@@ -28,7 +28,7 @@ function calcOffset(metaWindow) {
     return [x_offset, y_offset];
 }
 
-class Minimap extends Array {
+var Minimap = class Minimap extends Array {
     constructor(space, monitor) {
         super();
         this.space = space;

--- a/prefs.js
+++ b/prefs.js
@@ -55,7 +55,7 @@ function getOk(okValue) {
     }
 }
 
-class SettingsWidget {
+var SettingsWidget = class SettingsWidget {
     /**
        selectedWorkspace: index of initially selected workspace in workspace settings tab
        selectedTab: index of initially shown tab

--- a/settings.js
+++ b/settings.js
@@ -217,7 +217,7 @@ function keystrToKeycombo(keystr) {
         keystr = keystr.replace('Above_Tab', 'A');
         aboveTab = true;
     }
-    let [success, key, mask] = Gtk.accelerator_parse(keystr);
+    let [key, mask] = Gtk.accelerator_parse(keystr);
 
     if (aboveTab)
         key = META_KEY_ABOVE_TAB;

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -67,7 +67,7 @@ function createAppIcon(metaWindow, size) {
 
 /**
  */
-class ClickOverlay {
+var ClickOverlay = class ClickOverlay {
     constructor(monitor, onlyOnPrimary) {
         this.monitor = monitor;
         this.onlyOnPrimary = onlyOnPrimary;

--- a/tiling.js
+++ b/tiling.js
@@ -110,7 +110,7 @@ function init() {
 
    To transform a stage point to space coordinates: `space.actor.transform_stage_point(aX, aY)`
  */
-class Space extends Array {
+var Space = class Space extends Array {
     constructor (workspace, container, doInit) {
         super(0);
         this.workspace = workspace;
@@ -1342,7 +1342,7 @@ var StackPositions = {
 
    TODO: Move initialization to enable
 */
-class Spaces extends Map {
+var Spaces = class Spaces extends Map {
     // Fix for eg. space.map, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Species
     static get [Symbol.species]() { return Map; }
 

--- a/topbar.js
+++ b/topbar.js
@@ -86,9 +86,9 @@ var PopupMenuEntryHelper = function constructor(text) {
         this.prevIcon.grab_key_focus();
     });
 
-    this.actor.add_actor(this.prevIcon, {expand: true});
-    this.actor.add_actor(this.label, {expand: true});
-    this.actor.add_actor(this.nextIcon, {expand: true});
+    this.actor.add_actor(this.prevIcon);
+    this.actor.add_actor(this.label);
+    this.actor.add_actor(this.nextIcon);
     this.actor.label_actor = this.label;
     this.label.clutter_text.connect('activate', this.emit.bind(this, 'activate'));
 }
@@ -202,7 +202,7 @@ class WorkspaceMenu extends PanelMenu.Button {
     _init() {
         super._init(0.5, 'Workspace', false);
 
-        this.actor.name = 'workspace-button';
+        this.name = 'workspace-button';
 
         let scale = display.get_monitor_scale(Main.layoutManager.primaryIndex);
         this._label = new St.Label({
@@ -214,7 +214,7 @@ class WorkspaceMenu extends PanelMenu.Button {
 
         this.setName(Meta.prefs_get_workspace_name(workspaceManager.get_active_workspace_index()));
 
-        this.actor.add_actor(this._label);
+        this.add_actor(this._label);
 
         this.signals = new Utils.Signals();
         this.signals.connect(global.window_manager,
@@ -420,6 +420,8 @@ class WorkspaceMenu extends PanelMenu.Button {
                 let y = this.selected.actor.y;
                 let friction = 0.5;
                 while (test()) {
+
+                    log("while start")
                     let dy = this.velocity*16;
                     y -= dy;
                     // log(`calc target: ${dy} ${y} ${this.velocity}`);
@@ -493,7 +495,7 @@ var menu;
 var orginalActivitiesText;
 var screenSignals, signals;
 function init () {
-    let label = Main.panel.statusArea.activities.actor.first_child;
+    let label = Main.panel.statusArea.activities.first_child;
     orginalActivitiesText = label.text;
     screenSignals = [];
     signals = new Utils.Signals();
@@ -501,17 +503,17 @@ function init () {
 
 var panelBoxShowId, panelBoxHideId;
 function enable () {
-    Main.panel.statusArea.activities.actor.hide();
+    Main.panel.statusArea.activities.hide();
 
     menu = new WorkspaceMenu();
     // Work around 'actor' warnings
-    let panelActor = Main.panel.actor;
+    let panel = Main.panel;
     function fixLabel(label) {
         let point = new Clutter.Vertex({x: 0, y: 0});
-        let r = label.apply_relative_transform_to_point(panelActor, point);
+        let r = label.apply_relative_transform_to_point(panel, point);
 
         for (let [workspace, space] of Tiling.spaces) {
-            space.label.set_position(panelActor.x + Math.round(r.x), panelActor.y + Math.round(r.y));
+            space.label.set_position(panel.x + Math.round(r.x), panel.y + Math.round(r.y));
             let fontDescription = label.clutter_text.font_description;
             space.label.clutter_text.set_font_description(fontDescription);
         }
@@ -520,9 +522,7 @@ function enable () {
     menu.actor.show();
 
     // Force transparency
-    panelActor.set_style('background-color: rgba(0, 0, 0, 0.35);');
-    [Main.panel._rightCorner, Main.panel._leftCorner]
-        .forEach(c => c.actor.opacity = 0);
+    panel.set_style('background-color: rgba(0, 0, 0, 0.35);');
 
     screenSignals.push(
         workspaceManager.connect_after('workspace-switched',

--- a/utils.js
+++ b/utils.js
@@ -408,7 +408,7 @@ function printActorTree(node, fmt=mkFmt(), options={}, state=null) {
     }
 }
 
-class Signals extends Map {
+var Signals = class Signals extends Map {
     static get [Symbol.species]() { return Map; }
 
     _getOrCreateSignals(object) {


### PR DESCRIPTION
Within the initial preference settings fixes, both
Gtk.accelerator_parse() functions were changed to use the new GTK4
return values.

GTK4 is only used for the preference display so this broke the keybind
override function. Reverting the non-pref keybind parser to the GTK3
signature fixes this.